### PR TITLE
feat: Goとmysqlをdockerで環境構築する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/tmp
+/docker/mysql/db/mysql_data

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+reset_migration:
+	./docker/mysql/db/init/init-mysql.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 ENV_LOCAL_FILE = env.local
 ENV_LOCAL = $(shell cat $(ENV_LOCAL_FILE))
 
-
 run:
 	$(ENV_LOCAL) docker-compose up
 

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
+ENV_LOCAL_FILE = env.local
+ENV_LOCAL = $(shell cat $(ENV_LOCAL_FILE))
+
+
+run:
+	$(ENV_LOCAL) docker-compose up
+
 reset_migration:
-	./docker/mysql/db/init/init-mysql.sh
+	$(ENV_LOCAL) sh ./docker/mysql/db/init/init-mysql.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 ## About
 
 gRPC を用いてリアルタイムチャットアプリを作ってみる(server 側)
+
+## Setup
+
+- サーバーを 8080 ポートで起動する
+
+```
+$ make run
+```
+
+- MySQL のデータを初期化する
+
+```
+$ make reset_migration
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+services:
+  db:
+    container_name: chat-go-server-db
+    image: mysql
+    volumes:
+      - ./docker/mysql/db/mysql_data:/var/lib/mysql
+      - ./docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./docker/mysql/db/init:/docker-entrypoint-initdb.d
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: chat_go_server
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password
+    command: mysqld
+
+  api:
+    container_name: chat-go-server-api
+    build:
+      context: .
+      dockerfile: ./docker/api/Dockerfile
+    volumes:
+      - ./:/go/src/github.com/karamaru-alpha/chat-go-server
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: chat_go_server
-      MYSQL_USER: root
-      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     command: mysqld
 
   api:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.16
+
+WORKDIR /go/src/github.com/karamaru-alpha/chat-go-server
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . ./
+RUN go build .
+
+RUN go get github.com/pilu/fresh
+
+EXPOSE 8080
+
+CMD ["fresh"]

--- a/docker/mysql/db/init/001-ddl.sql
+++ b/docker/mysql/db/init/001-ddl.sql
@@ -1,0 +1,12 @@
+CREATE DATABASE IF NOT EXISTS `chat_go_server`;
+USE `chat_go_server`;
+
+DROP TABLE IF EXISTS `rooms`;
+
+CREATE TABLE IF NOT EXISTS `rooms` (
+  `id`    INT AUTO_INCREMENT NOT NULL COMMENT 'トークルームID',
+  `title` VARCHAR(64) NOT NULL UNIQUE COMMENT 'トークルーム名',
+  PRIMARY KEY (`id`))
+ENGINE=InnoDB
+COMMENT='トークルーム'
+DEFAULT CHARSET=utf8mb4;

--- a/docker/mysql/db/init/001-ddl.sql
+++ b/docker/mysql/db/init/001-ddl.sql
@@ -1,6 +1,3 @@
-CREATE DATABASE IF NOT EXISTS `chat_go_server`;
-USE `chat_go_server`;
-
 DROP TABLE IF EXISTS `rooms`;
 
 CREATE TABLE IF NOT EXISTS `rooms` (

--- a/docker/mysql/db/init/002-dml.sql
+++ b/docker/mysql/db/init/002-dml.sql
@@ -1,0 +1,6 @@
+USE chat_go_server;
+
+DELETE FROM `rooms`;
+INSERT INTO `rooms` (`title`) VALUES ("ルームA");
+INSERT INTO `rooms` (`title`) VALUES ("ルームB");
+INSERT INTO `rooms` (`title`) VALUES ("ルームC");

--- a/docker/mysql/db/init/002-dml.sql
+++ b/docker/mysql/db/init/002-dml.sql
@@ -1,5 +1,3 @@
-USE chat_go_server;
-
 DELETE FROM `rooms`;
 INSERT INTO `rooms` (`title`) VALUES ("ルームA");
 INSERT INTO `rooms` (`title`) VALUES ("ルームB");

--- a/docker/mysql/db/init/init-database.sh
+++ b/docker/mysql/db/init/init-database.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-mysql -u root -ppassword chat_go_server < "/docker-entrypoint-initdb.d/001-ddl.sql"
-mysql -u root -ppassword chat_go_server < "/docker-entrypoint-initdb.d/002-dml.sql"
+mysql -u$MYSQL_USER -p$MYSQL_ROOT_PASSWORD $MYSQL_DATABASE < "/docker-entrypoint-initdb.d/001-ddl.sql"
+mysql -u$MYSQL_USER -p$MYSQL_ROOT_PASSWORD $MYSQL_DATABASE < "/docker-entrypoint-initdb.d/002-dml.sql"

--- a/docker/mysql/db/init/init-database.sh
+++ b/docker/mysql/db/init/init-database.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mysql -u root -ppassword chat_go_server < "/docker-entrypoint-initdb.d/001-ddl.sql"
+mysql -u root -ppassword chat_go_server < "/docker-entrypoint-initdb.d/002-dml.sql"

--- a/docker/mysql/db/init/init-mysql.sh
+++ b/docker/mysql/db/init/init-mysql.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker-compose exec db bash -c "chmod 0775 docker-entrypoint-initdb.d/init-database.sh"
+docker-compose exec db bash -c "./docker-entrypoint-initdb.d/init-database.sh"

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+default_authentication_plugin=mysql_native_password
+lower_case_table_names=2
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+
+[mysql]
+default-character-set=utf8mb4
+
+[client]
+default-character-set=utf8mb4

--- a/env.local
+++ b/env.local
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=password
+MYSQL_DATABASE=chat_go_server
+MYSQL_USER=root
+MYSQL_PASSWORD=password

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/karamaru-alpha/chat-go-server
+
+go 1.16

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Print("Hello World!")
+}


### PR DESCRIPTION
## About
Goとmysqlをdockerで環境構築する

## Details
- `env.local`に環境変数を入れて、makefileでそれを参照。docker-composeやshで使い回すように

## Preview
`$ run`: goとmysqlを起動
`$ reset_migrate` migrationを初期状態に戻す