### PR TITLE
feat: トークルームのドメイン層を実装

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.14.0
+    steps:
+      - checkout
+      - run:
+          name: Install golangci-lint@v1.30.0
+          command: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
+      - run:
+          name: Run golangci-lint
+          command: golangci-lint run
+      - run:
+          name: Run test
+          command: go test ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14.0
+      - image: circleci/golang:1.16.0
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 ENV_LOCAL_FILE = env.local
 ENV_LOCAL = $(shell cat $(ENV_LOCAL_FILE))
 
+.PHONY:run
 run:
 	$(ENV_LOCAL) docker-compose up
 
+
+.PHONY:reset_migration
 reset_migration:
 	$(ENV_LOCAL) sh ./docker/mysql/db/init/init-mysql.sh
 
+.PHONY:test
+test:
+	go test ./...
+
+.PHONY:lint
 lint:
 	go mod tidy
 	golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ ENV_LOCAL = $(shell cat $(ENV_LOCAL_FILE))
 run:
 	$(ENV_LOCAL) docker-compose up
 
-
 .PHONY:reset_migration
 reset_migration:
 	$(ENV_LOCAL) sh ./docker/mysql/db/init/init-mysql.sh

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ run:
 
 reset_migration:
 	$(ENV_LOCAL) sh ./docker/mysql/db/init/init-mysql.sh
+
+lint:
+	go mod tidy
+	golangci-lint run ./...

--- a/domain/model/room/entity.go
+++ b/domain/model/room/entity.go
@@ -1,0 +1,22 @@
+package room
+
+import "errors"
+
+// Room トークルームを表現するエンティティ
+type Room struct {
+	ID    ID
+	Title Title
+}
+
+// NewRoom Roomエンティティを構築するコンストラクタ
+func NewRoom(id *ID, title *Title) (*Room, error) {
+
+	if id == nil {
+		return nil, errors.New("RoomID is null")
+	}
+	if title == nil {
+		return nil, errors.New("RoomTitle is null")
+	}
+
+	return &Room{ID: *id, Title: *title}, nil
+}

--- a/domain/model/room/factory.go
+++ b/domain/model/room/factory.go
@@ -1,0 +1,27 @@
+package room
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/oklog/ulid"
+)
+
+// Create Roomエンティティの生成処理を担うファクトリ
+func Create(title *Title) (*Room, error) {
+
+	ulid := generateULID()
+
+	roomID, err := NewID(&ulid)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRoom(roomID, title)
+}
+
+func generateULID() ulid.ULID {
+	t := time.Now()
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(t.UnixNano())), 0)
+	return ulid.MustNew(ulid.Timestamp(t), entropy)
+}

--- a/domain/model/room/id.go
+++ b/domain/model/room/id.go
@@ -1,0 +1,21 @@
+package room
+
+import (
+	"errors"
+
+	"github.com/oklog/ulid"
+)
+
+// ID トークルームの識別子を表現する値オブジェクト
+type ID ulid.ULID
+
+// NewID トークルームIDの値オブジェクトを生成するコンストラクタ
+func NewID(v *ulid.ULID) (*ID, error) {
+
+	if v == nil {
+		return nil, errors.New("RoomID is null")
+	}
+
+	id := ID(*v)
+	return &id, nil
+}

--- a/domain/model/room/repository.go
+++ b/domain/model/room/repository.go
@@ -1,0 +1,7 @@
+package room
+
+// IRepository トークルームを永続化・再構築するリポジトリ
+type IRepository interface {
+	Save(*Room) error
+	FindAll() (*[]Room, error)
+}

--- a/domain/model/room/title.go
+++ b/domain/model/room/title.go
@@ -15,7 +15,7 @@ func NewTitle(v string) (*Title, error) {
 		return nil, errors.New("RoomTitle is null")
 	}
 
-	if utf8.RuneCountInString(v) < 3 || utf8.RuneCountInString(v) > 20 {
+	if utf8.RuneCountInString(v) < 3 || utf8.RuneCountInString(v) > 50 {
 		return nil, errors.New("RoomTitle should be Three to twenty characters")
 	}
 

--- a/domain/model/room/title.go
+++ b/domain/model/room/title.go
@@ -1,0 +1,24 @@
+package room
+
+import (
+	"errors"
+	"unicode/utf8"
+)
+
+// Title トークルーム名を表現する値オブジェクト
+type Title string
+
+// NewTitle トークルーム名の値オブジェクトを生成するコンストラクタ
+func NewTitle(v string) (*Title, error) {
+
+	if v == "" {
+		return nil, errors.New("RoomTitle is null")
+	}
+
+	if utf8.RuneCountInString(v) < 3 || utf8.RuneCountInString(v) > 20 {
+		return nil, errors.New("RoomTitle should be Three to twenty characters")
+	}
+
+	title := Title(v)
+	return &title, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/karamaru-alpha/chat-go-server
 
 go 1.16
+
+require (
+	github.com/oklog/ulid v1.3.1
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
+github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/domain/model/room/entity_test.go
+++ b/test/domain/model/room/entity_test.go
@@ -1,0 +1,60 @@
+package room
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+// TestNewRoom トークルームコンストラクタのテスト
+func TestNewRoom(t *testing.T) {
+	t.Parallel()
+
+	roomID := domainModel.ID(testData.id.valid)
+	roomTitle := domainModel.Title(testData.title.valid)
+
+	tests := []struct {
+		title     string
+		input1    *domainModel.ID
+		input2    *domainModel.Title
+		expected1 *domainModel.Room
+		expected2 error
+	}{
+		{
+			title:     "【正常系】",
+			input1:    &roomID,
+			input2:    &roomTitle,
+			expected1: &domainModel.Room{ID: roomID, Title: roomTitle},
+			expected2: nil,
+		},
+		{
+			title:     "【異常系】IDがnil",
+			input1:    nil,
+			input2:    &roomTitle,
+			expected1: &domainModel.Room{ID: roomID, Title: roomTitle},
+			expected2: errors.New("RoomID is null"),
+		},
+		{
+			title:     "【異常系】Titleがnil",
+			input1:    &roomID,
+			input2:    nil,
+			expected1: &domainModel.Room{ID: roomID, Title: roomTitle},
+			expected2: errors.New("RoomTitle is null"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("NewRoom:"+td.title, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewRoom(td.input1, td.input2)
+
+			assert.IsType(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/room/factory_test.go
+++ b/test/domain/model/room/factory_test.go
@@ -1,0 +1,43 @@
+package room
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+// TestCreate トークルーム生成処理を担うファクトリのテスト
+func TestCreate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title      string
+		input      *domainModel.Title
+		expected1T interface{} // uuidのモックが大変なので型のみで判定
+		expected2  error
+	}{
+		{
+			title: "【正常系】",
+			input: (func(v string) *domainModel.Title {
+				title := domainModel.Title(v)
+				return &title
+			})(testData.title.valid),
+			expected1T: new(domainModel.Room),
+			expected2:  nil,
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("Create:"+td.title, func(t *testing.T) {
+
+			output1, output2 := domainModel.Create(td.input)
+
+			assert.IsType(t, td.expected1T, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/room/id_test.go
+++ b/test/domain/model/room/id_test.go
@@ -1,0 +1,50 @@
+package room
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+// TestNewID トークルームIDの値オブジェクトコンストラクタテスト
+func TestNewID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title     string
+		input     *ulid.ULID
+		expected1 *domainModel.ID
+		expected2 error
+	}{
+		{
+			title: "【正常系】",
+			input: &testData.id.valid,
+			expected1: (func(v *ulid.ULID) *domainModel.ID {
+				id := domainModel.ID(*v)
+				return &id
+			})(&testData.id.valid),
+			expected2: nil,
+		},
+		{
+			title:     "【異常系】引数がnil",
+			input:     nil,
+			expected1: nil,
+			expected2: errors.New("RoomID is null"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+		t.Run("NewID:"+td.title, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewID(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/room/test_data.go
+++ b/test/domain/model/room/test_data.go
@@ -1,0 +1,31 @@
+package room
+
+import (
+	"strings"
+
+	"github.com/oklog/ulid"
+)
+
+var testData = struct {
+	id    idTestData
+	title titleTestData
+}{
+	id: idTestData{
+		valid: ulid.MustParse("01D0KDBRASGD5HRSNDCKA0AH53"),
+	},
+	title: titleTestData{
+		valid:    "valid_title",
+		tooShort: ".",
+		tooLong:  strings.Repeat("a", 100),
+	},
+}
+
+type idTestData struct {
+	valid ulid.ULID
+}
+
+type titleTestData struct {
+	valid    string
+	tooShort string
+	tooLong  string
+}

--- a/test/domain/model/room/title_test.go
+++ b/test/domain/model/room/title_test.go
@@ -1,0 +1,61 @@
+package room
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+// TestNewTitle トークルーム名値オブジェクトコンストラクタのテスト
+func TestNewTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title     string
+		input     string
+		expected1 *domainModel.Title
+		expected2 error
+	}{
+		{
+			title: "【正常系】",
+			input: testData.title.valid,
+			expected1: (func(v string) *domainModel.Title {
+				title := domainModel.Title(v)
+				return &title
+			})(testData.title.valid),
+			expected2: nil,
+		},
+		{
+			title:     "【異常系】タイトルが空",
+			input:     "",
+			expected1: nil,
+			expected2: errors.New("RoomTitle is null"),
+		},
+		{
+			title:     "【異常系】タイトルが短い",
+			input:     testData.title.tooShort,
+			expected1: nil,
+			expected2: errors.New("RoomTitle should be Three to twenty characters"),
+		},
+		{
+			title:     "【異常系】タイトルが長い",
+			input:     testData.title.tooLong,
+			expected1: nil,
+			expected2: errors.New("RoomTitle should be Three to twenty characters"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+		t.Run("NewTitle:"+td.title, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewTitle(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}


### PR DESCRIPTION
## About
トークルーム(room)のドメイン層を実装

## Background
レイヤードにドメインを管理し、テストを自動化させたいので。

## Details
- Domain/model層にはエンティティ・値オブジェクト・ファクトリ・リポジトリがある。(いずれもエンティティの構築に不可欠なので同じディレクトリです)
- エンティティ・値オブジェクト・ファクトリのテストを記述。`test_data.go`で各ケースのinputを管理
- テストをciで自動化・makefileで簡易化した

## Remarks
- repositoryの実装ファイル、factoryの呼び出しファイルは次回実装

## Preview
```
$ tree ./
```
<img width="298" alt="スクリーンショット 2021-03-15 17 58 56" src="https://user-images.githubusercontent.com/38310693/111128345-1e137380-85b8-11eb-8046-11c706fc1b39.png">

