### PR TITLE
feat: トークルームの永続化のテスト

### DIFF
--- a/test/infrastructure/mysql/room/dto_test.go
+++ b/test/infrastructure/mysql/room/dto_test.go
@@ -41,6 +41,7 @@ func TestToDTO(t *testing.T) {
 	}
 }
 
+// TestToEntity DB情報を持ったトークルームDTOをEntityに変換する処理のテスト
 func TestToEntity(t *testing.T) {
 	t.Parallel()
 
@@ -102,6 +103,7 @@ func TestToEntity(t *testing.T) {
 	}
 }
 
+// TestToEntities DB情報を持ったトークルームDTOをEntityのリストに変換する処理のテスト
 func TestToEntities(t *testing.T) {
 	t.Parallel()
 

--- a/test/infrastructure/mysql/room/repository_impl_test.go
+++ b/test/infrastructure/mysql/room/repository_impl_test.go
@@ -1,88 +1,69 @@
 package room
 
-// TODO implment repository impl test
+import (
+	"regexp"
+	"testing"
 
-// import (
-// 	"regexp"
-// 	"testing"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jinzhu/gorm"
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
 
-// 	"github.com/DATA-DOG/go-sqlmock"
-// 	"github.com/jinzhu/gorm"
-// 	"github.com/oklog/ulid"
-// 	"github.com/stretchr/testify/assert"
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
+	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
+)
 
-// 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-// 	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
-// 	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
-// )
+type repositoryImplTest struct {
+	repositoryImpl domainModel.IRepository
+	db             *gorm.DB
+	mock           sqlmock.Sqlmock
+}
 
-// type repositoryImplTest struct {
-// 	repositoryImpl domainModel.IRepository
-// 	db             *gorm.DB
-// 	mock           sqlmock.Sqlmock
-// }
+// TestSave トークルームを永続化させる処理のテスト
+func TestSave(t *testing.T) {
 
-// func TestSave(t *testing.T) {
-// 	t.Parallel()
+	// 永続化したいトークルームの準備
+	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
+	assert.NoError(t, err)
+	room, err := domainModel.Create(roomTitle)
+	assert.NoError(t, err)
 
-// 	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-// 	assert.NoError(t, err)
-// 	room, err := domainModel.Create(roomTitle)
-// 	assert.NoError(t, err)
+	// モックの作成
+	test := repositoryImplTest{}
+	test.setupTest(t)
 
-// 	test := repositoryImplTest{}
-// 	test.setupTest(t)
+	test.mock.ExpectBegin()
+	test.mock.ExpectExec(
+		regexp.QuoteMeta("INSERT INTO `rooms` (`id`,`title`)"),
+	).WithArgs(ulid.ULID(room.ID).String(), string(room.Title)).WillReturnResult(sqlmock.NewResult(1, 1))
+	test.mock.ExpectCommit()
 
-// 	test.mock.ExpectBegin()
+	// 実行
+	err = test.repositoryImpl.Save(room)
+	assert.NoError(t, err)
 
-// 	test.mock.ExpectExec(
-// 		regexp.QuoteMeta("INSERT INTO \"rooms\" (\"id\", \"title\") VALUES (?, ?)"),
-// 	).WithArgs(ulid.ULID(room.ID).String(), string(room.Title))
+	err = test.mock.ExpectationsWereMet()
+	assert.NoError(t, err)
 
-// 	test.mock.ExpectCommit()
+	test.TeardownTest(t)
+}
 
-// 	tests := []struct {
-// 		title   string
-// 		input   *domainModel.Room
-// 		isError bool
-// 	}{
-// 		{
-// 			title:   "【正常系】",
-// 			input:   room,
-// 			isError: false,
-// 		},
-// 	}
+func (r *repositoryImplTest) setupTest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
 
-// 	for _, td := range tests {
-// 		td := td
+	gormDB, err := gorm.Open("mysql", db)
+	assert.NoError(t, err)
+	gormDB.LogMode(true)
 
-// 		err := test.repositoryImpl.Save(td.input)
+	repositoryImpl := infra.NewRepositoryImpl(gormDB)
 
-// 		if td.isError {
-// 			assert.Error(t, err)
-// 		} else {
-// 			assert.NoError(t, err)
-// 		}
-// 	}
+	r.db = gormDB
+	r.mock = mock
+	r.repositoryImpl = repositoryImpl
+}
 
-// 	test.TeardownTest(t)
-// }
-
-// func (r *repositoryImplTest) setupTest(t *testing.T) {
-// 	db, mock, err := sqlmock.New()
-// 	assert.NoError(t, err)
-
-// 	gormDB, err := gorm.Open("mysql", db)
-// 	assert.NoError(t, err)
-
-// 	repositoryImpl := infra.NewRepositoryImpl(gormDB)
-
-// 	r.db = gormDB
-// 	r.mock = mock
-// 	r.repositoryImpl = repositoryImpl
-// }
-
-// func (r *repositoryImplTest) TeardownTest(t *testing.T) {
-// 	err := r.db.Close()
-// 	assert.NoError(t, err)
-// }
+func (r *repositoryImplTest) TeardownTest(t *testing.T) {
+	r.db.Close()
+}


### PR DESCRIPTION
## About
トークルームの永続化のテスト実装

## Details
- sqlmockを使用し、DB通信をmock
- DBのOpen/Closeを関数で切り出した
- 一旦正常系のみ

## Remarks
- 一覧取得のrepoimplも作成する

