### PR TITLE
refactor: テストデータを型ごとに分類する

### DIFF
--- a/mock/util/ulid_generator_mock.go
+++ b/mock/util/ulid_generator_mock.go
@@ -1,11 +1,12 @@
 package util
 
 import (
-	"github.com/karamaru-alpha/chat-go-server/test/testdata"
 	"github.com/oklog/ulid"
+
+	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
 // GenerateULID ULID生成処理を固定値でモックした関数
 func GenerateULID() ulid.ULID {
-	return testdata.Room.ID.Valid
+	return tdULID.Room.ID.Valid
 }

--- a/test/application/room/create/interactor_test.go
+++ b/test/application/room/create/interactor_test.go
@@ -11,7 +11,8 @@ import (
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/room"
 	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
-	"github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 
 // TestHandle トークルームを作成するアプリケーションサービスのテスト
@@ -22,17 +23,11 @@ func TestHandle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// 正常なリクエストが来た場合に永続化したいRoomEntityを作成
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
-	room, err := factory.Create(roomTitle)
-	assert.NoError(t, err)
-
 	// reposityをモック
 	repository := mockDomainModel.NewMockIRepository(ctrl)
-	repository.EXPECT().Save(room).Return(nil)
+	repository.EXPECT().Save(&tdDomain.Room.Entity.Valid).Return(nil)
 
+	factory := domainModel.NewFactory(mockUtil.GenerateULID)
 	interactor := application.NewInteractor(factory, repository)
 
 	tests := []struct {
@@ -43,17 +38,17 @@ func TestHandle(t *testing.T) {
 		{
 			title: "【正常系】",
 			input: application.InputData{
-				Title: testdata.Room.Title.Valid,
+				Title: tdString.Room.Title.Valid,
 			},
 			expected: application.OutputData{
-				Room: room,
+				Room: &tdDomain.Room.Entity.Valid,
 				Err:  nil,
 			},
 		},
 		{
 			title: "【異常系】タイトルが短い",
 			input: application.InputData{
-				Title: testdata.Room.Title.TooShort,
+				Title: tdString.Room.Title.TooShort,
 			},
 			expected: application.OutputData{
 				Room: nil,
@@ -63,7 +58,7 @@ func TestHandle(t *testing.T) {
 		{
 			title: "【異常系】タイトルが長い",
 			input: application.InputData{
-				Title: testdata.Room.Title.TooLong,
+				Title: tdString.Room.Title.TooLong,
 			},
 			expected: application.OutputData{
 				Room: nil,

--- a/test/application/room/find_all/interactor_test.go
+++ b/test/application/room/find_all/interactor_test.go
@@ -9,8 +9,7 @@ import (
 	application "github.com/karamaru-alpha/chat-go-server/application/room/find_all"
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/room"
-	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
-	"github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
 )
 
 // TestHandle トークルームを全件取得するアプリケーションサービスのテスト
@@ -21,16 +20,9 @@ func TestHandle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// 再構築したいRoomEntityを準備
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
-	room, err := factory.Create(roomTitle)
-	assert.NoError(t, err)
-
 	// reposityをモック
 	repository := mockDomainModel.NewMockIRepository(ctrl)
-	repository.EXPECT().FindAll().Return(&[]domainModel.Room{*room}, nil)
+	repository.EXPECT().FindAll().Return(&[]domainModel.Room{tdDomain.Room.Entity.Valid}, nil)
 
 	interactor := application.NewInteractor(repository)
 
@@ -41,7 +33,7 @@ func TestHandle(t *testing.T) {
 		{
 			title: "【正常系】",
 			expected: application.OutputData{
-				Rooms: &[]domainModel.Room{*room},
+				Rooms: &[]domainModel.Room{tdDomain.Room.Entity.Valid},
 				Err:   nil,
 			},
 		},

--- a/test/domain/model/room/entity_test.go
+++ b/test/domain/model/room/entity_test.go
@@ -7,18 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
 )
 
 // TestNewRoom トークルームコンストラクタのテスト
 func TestNewRoom(t *testing.T) {
 	t.Parallel()
-
-	roomID, err := domainModel.NewID(&testdata.Room.ID.Valid)
-	assert.NoError(t, err)
-
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
 
 	tests := []struct {
 		title     string
@@ -29,23 +23,23 @@ func TestNewRoom(t *testing.T) {
 	}{
 		{
 			title:     "【正常系】",
-			input1:    roomID,
-			input2:    roomTitle,
-			expected1: &domainModel.Room{ID: *roomID, Title: *roomTitle},
+			input1:    &tdDomain.Room.ID.Valid,
+			input2:    &tdDomain.Room.Title.Valid,
+			expected1: &tdDomain.Room.Entity.Valid,
 			expected2: nil,
 		},
 		{
 			title:     "【異常系】IDがnil",
 			input1:    nil,
-			input2:    roomTitle,
-			expected1: &domainModel.Room{ID: *roomID, Title: *roomTitle},
+			input2:    &tdDomain.Room.Title.Valid,
+			expected1: nil,
 			expected2: errors.New("RoomID is null"),
 		},
 		{
 			title:     "【異常系】Titleがnil",
-			input1:    roomID,
+			input1:    &tdDomain.Room.ID.Valid,
 			input2:    nil,
-			expected1: &domainModel.Room{ID: *roomID, Title: *roomTitle},
+			expected1: nil,
 			expected2: errors.New("RoomTitle is null"),
 		},
 	}
@@ -57,7 +51,7 @@ func TestNewRoom(t *testing.T) {
 
 			output1, output2 := domainModel.NewRoom(td.input1, td.input2)
 
-			assert.IsType(t, td.expected1, output1)
+			assert.Equal(t, td.expected1, output1)
 			assert.Equal(t, td.expected2, output2)
 		})
 	}

--- a/test/domain/model/room/factory_test.go
+++ b/test/domain/model/room/factory_test.go
@@ -7,15 +7,12 @@ import (
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
-	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
 )
 
 // TestCreate トークルーム生成処理を担うファクトリのテスト
 func TestCreate(t *testing.T) {
 	t.Parallel()
-
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
 
 	factory := domainModel.NewFactory(mockUtil.GenerateULID)
 
@@ -27,8 +24,8 @@ func TestCreate(t *testing.T) {
 	}{
 		{
 			title:     "【正常系】",
-			input:     roomTitle,
-			expected1: &domainModel.Room{ID: domainModel.ID(testdata.Room.ID.Valid), Title: *roomTitle},
+			input:     &tdDomain.Room.Title.Valid,
+			expected1: &tdDomain.Room.Entity.Valid,
 			expected2: nil,
 		},
 	}

--- a/test/domain/model/room/id_test.go
+++ b/test/domain/model/room/id_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
 // TestNewID トークルームIDの値オブジェクトコンストラクタテスト
@@ -22,12 +23,9 @@ func TestNewID(t *testing.T) {
 		expected2 error
 	}{
 		{
-			title: "【正常系】",
-			input: &testdata.Room.ID.Valid,
-			expected1: (func(v *ulid.ULID) *domainModel.ID {
-				id := domainModel.ID(*v)
-				return &id
-			})(&testdata.Room.ID.Valid),
+			title:     "【正常系】",
+			input:     &tdULID.Room.ID.Valid,
+			expected1: &tdDomain.Room.ID.Valid,
 			expected2: nil,
 		},
 		{

--- a/test/domain/model/room/title_test.go
+++ b/test/domain/model/room/title_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 
 // TestNewTitle トークルーム名値オブジェクトコンストラクタのテスト
@@ -21,12 +22,9 @@ func TestNewTitle(t *testing.T) {
 		expected2 error
 	}{
 		{
-			title: "【正常系】",
-			input: testdata.Room.Title.Valid,
-			expected1: (func(v string) *domainModel.Title {
-				title := domainModel.Title(v)
-				return &title
-			})(testdata.Room.Title.Valid),
+			title:     "【正常系】",
+			input:     tdString.Room.Title.Valid,
+			expected1: &tdDomain.Room.Title.Valid,
 			expected2: nil,
 		},
 		{
@@ -37,13 +35,13 @@ func TestNewTitle(t *testing.T) {
 		},
 		{
 			title:     "【異常系】タイトルが短い",
-			input:     testdata.Room.Title.TooShort,
+			input:     tdString.Room.Title.TooShort,
 			expected1: nil,
 			expected2: errors.New("RoomTitle should be Three to twenty characters"),
 		},
 		{
 			title:     "【異常系】タイトルが長い",
-			input:     testdata.Room.Title.TooLong,
+			input:     tdString.Room.Title.TooLong,
 			expected1: nil,
 			expected2: errors.New("RoomTitle should be Three to twenty characters"),
 		},

--- a/test/infrastructure/mysql/room/dto_test.go
+++ b/test/infrastructure/mysql/room/dto_test.go
@@ -4,27 +4,17 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/oklog/ulid"
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
-	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
-	testdata "github.com/karamaru-alpha/chat-go-server/test/testdata"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 
 // TestToDTO トークルームEntityをDB情報を持つDTOに変換する処理のテスト
 func TestToDTO(t *testing.T) {
 	t.Parallel()
-
-	// DTOに入れるEntityの準備
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
-
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
-
-	room, err := factory.Create(roomTitle)
-	assert.NoError(t, err)
 
 	tests := []struct {
 		title    string
@@ -33,8 +23,8 @@ func TestToDTO(t *testing.T) {
 	}{
 		{
 			title:    "【正常系】",
-			input:    room,
-			expected: &infra.Room{ID: ulid.ULID(room.ID).String(), Title: string(room.Title)},
+			input:    &tdDomain.Room.Entity.Valid,
+			expected: &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.Valid},
 		},
 	}
 
@@ -51,18 +41,6 @@ func TestToDTO(t *testing.T) {
 func TestToEntity(t *testing.T) {
 	t.Parallel()
 
-	// Entityに変換するDTOの準備
-	dto := &infra.Room{ID: testdata.Room.ID.ValidPlain, Title: testdata.Room.Title.Valid}
-
-	// DTOから生成されるであろうEntityの準備
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
-
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
-
-	room, err := factory.Create(roomTitle)
-	assert.NoError(t, err)
-
 	tests := []struct {
 		title     string
 		input     *infra.Room
@@ -71,19 +49,19 @@ func TestToEntity(t *testing.T) {
 	}{
 		{
 			title:     "【正常系】",
-			input:     dto,
-			expected1: room,
+			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.Valid},
+			expected1: &tdDomain.Room.Entity.Valid,
 			expected2: nil,
 		},
 		{
 			title:     "【異常系】タイトルが不正値(short)",
-			input:     &infra.Room{ID: testdata.Room.ID.ValidPlain, Title: testdata.Room.Title.TooShort},
+			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooShort},
 			expected1: nil,
 			expected2: errors.New("RoomTitle should be Three to twenty characters"),
 		},
 		{
 			title:     "【異常系】タイトルが不正値(long)",
-			input:     &infra.Room{ID: testdata.Room.ID.ValidPlain, Title: testdata.Room.Title.TooLong},
+			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooLong},
 			expected1: nil,
 			expected2: errors.New("RoomTitle should be Three to twenty characters"),
 		},
@@ -104,16 +82,7 @@ func TestToEntities(t *testing.T) {
 	t.Parallel()
 
 	// Entityに変換するDTOの準備
-	dto := infra.Room{ID: testdata.Room.ID.ValidPlain, Title: testdata.Room.Title.Valid}
-
-	// DTOから生成されるであろうEntityの準備
-	roomTitle, err := domainModel.NewTitle(testdata.Room.Title.Valid)
-	assert.NoError(t, err)
-
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
-
-	room, err := factory.Create(roomTitle)
-	assert.NoError(t, err)
+	dto := infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.Valid}
 
 	tests := []struct {
 		title     string
@@ -124,24 +93,24 @@ func TestToEntities(t *testing.T) {
 		{
 			title:     "【正常系】1つのDTOをEntityに変換",
 			input:     &[]infra.Room{dto},
-			expected1: &[]domainModel.Room{*room},
+			expected1: &[]domainModel.Room{tdDomain.Room.Entity.Valid},
 			expected2: nil,
 		},
 		{
 			title:     "【正常系】2つのDTOをEntityに変換",
 			input:     &[]infra.Room{dto, dto},
-			expected1: &[]domainModel.Room{*room, *room},
+			expected1: &[]domainModel.Room{tdDomain.Room.Entity.Valid, tdDomain.Room.Entity.Valid},
 			expected2: nil,
 		},
 		{
 			title:     "【異常系】タイトルが不正値(short)",
-			input:     &[]infra.Room{{ID: testdata.Room.ID.ValidPlain, Title: testdata.Room.Title.TooShort}},
+			input:     &[]infra.Room{{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooShort}},
 			expected1: nil,
 			expected2: errors.New("RoomTitle should be Three to twenty characters"),
 		},
 		{
 			title:     "【異常系】タイトルが不正値(long)",
-			input:     &[]infra.Room{{ID: testdata.Room.ID.ValidPlain, Title: testdata.Room.Title.TooLong}},
+			input:     &[]infra.Room{{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooLong}},
 			expected1: nil,
 			expected2: errors.New("RoomTitle should be Three to twenty characters"),
 		},

--- a/test/testdata/domain/room.go
+++ b/test/testdata/domain/room.go
@@ -1,0 +1,68 @@
+package testdata
+
+import (
+	"log"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
+	tdUlid "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
+)
+
+var Room = struct {
+	Entity entity
+	ID     id
+	Title  title
+}{
+	Entity: entity{
+		Valid: genRoom(),
+	},
+	ID: id{
+		Valid: genRoomID(),
+	},
+	Title: title{
+		Valid: genRoomTitle(),
+	},
+}
+
+type entity struct {
+	Valid domainModel.Room
+}
+
+type id struct {
+	Valid domainModel.ID
+}
+
+type title struct {
+	Valid domainModel.Title
+}
+
+func genRoom() domainModel.Room {
+	factory := domainModel.NewFactory(mockUtil.GenerateULID)
+
+	roomTitle := genRoomTitle()
+	room, err := factory.Create(&roomTitle)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *room
+}
+
+func genRoomID() domainModel.ID {
+	id, err := domainModel.NewID(&tdUlid.Room.ID.Valid)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *id
+}
+
+func genRoomTitle() domainModel.Title {
+	title, err := domainModel.NewTitle(tdString.Room.Title.Valid)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *title
+}

--- a/test/testdata/domain/room.go
+++ b/test/testdata/domain/room.go
@@ -6,7 +6,7 @@ import (
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
-	tdUlid "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
+	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
 var Room = struct {
@@ -50,7 +50,7 @@ func genRoom() domainModel.Room {
 }
 
 func genRoomID() domainModel.ID {
-	id, err := domainModel.NewID(&tdUlid.Room.ID.Valid)
+	id, err := domainModel.NewID(&tdULID.Room.ID.Valid)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/testdata/string/td.go
+++ b/test/testdata/string/td.go
@@ -2,8 +2,6 @@ package testdata
 
 import (
 	"strings"
-
-	"github.com/oklog/ulid"
 )
 
 var Room = struct {
@@ -11,9 +9,8 @@ var Room = struct {
 	Title roomTitle
 }{
 	ID: roomID{
-		ValidPlain:   "01D0KDBRASGD5HRSNDCKA0AH53",
-		InvalidPlain: "invalid_ulid",
-		Valid:        ulid.MustParse("01D0KDBRASGD5HRSNDCKA0AH53"),
+		Valid:   "01D0KDBRASGD5HRSNDCKA0AH53",
+		Invalid: "invalid_ulid",
 	},
 	Title: roomTitle{
 		Valid:    "valid_title",
@@ -23,9 +20,8 @@ var Room = struct {
 }
 
 type roomID struct {
-	ValidPlain   string
-	InvalidPlain string
-	Valid        ulid.ULID
+	Valid   string
+	Invalid string
 }
 
 type roomTitle struct {

--- a/test/testdata/ulid/td.go
+++ b/test/testdata/ulid/td.go
@@ -1,0 +1,17 @@
+package testdata
+
+import (
+	"github.com/oklog/ulid"
+)
+
+var Room = struct {
+	ID roomID
+}{
+	ID: roomID{
+		Valid: ulid.MustParse("01D0KDBRASGD5HRSNDCKA0AH53"),
+	},
+}
+
+type roomID struct {
+	Valid ulid.ULID
+}


### PR DESCRIPTION
## About
テストデータを型ごとに分類する
## Background
- テストデータの型がわかりずらかった
- ドメインについてもValidなEntityやVOを用意したかった
## Details
- domain / string / ulidなど、型ごとにディレクトリを切った
## Preview
<img width="338" alt="スクリーンショット 2021-03-25 10 15 59" src="https://user-images.githubusercontent.com/38310693/112404122-19d31d00-8d53-11eb-8b73-ec1dfbd7889d.png">
