### PR TITLE
refactor: UILDGeneratorをコンストラクタで生成する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ reset_migration:
 
 .PHONY:test
 test:
-	go test ./test/...
+	$(ENV_LOCAL) go test ./test/...
 
 .PHONY:lint
 lint:

--- a/domain/model/room/factory.go
+++ b/domain/model/room/factory.go
@@ -1,7 +1,7 @@
 package room
 
 import (
-	"github.com/oklog/ulid"
+	"github.com/karamaru-alpha/chat-go-server/mock/util"
 )
 
 // IFactory Roomエンティティの生成処理を担うFactoryのインターフェース
@@ -10,20 +10,20 @@ type IFactory interface {
 }
 
 type factory struct {
-	generateULID func() ulid.ULID
+	ulidGenerator util.IULIDGenerator
 }
 
 // NewFactory Roomエンティティの生成処理を担うFactoryのコンストラクタ
-func NewFactory(generateULID func() ulid.ULID) IFactory {
+func NewFactory(ulidGenerator util.IULIDGenerator) IFactory {
 	return &factory{
-		generateULID,
+		ulidGenerator,
 	}
 }
 
 // Create Roomエンティティの生成処理を担うファクトリ
 func (f factory) Create(title *Title) (*Room, error) {
 
-	ulid := f.generateULID()
+	ulid := f.ulidGenerator.Generate()
 
 	roomID, err := NewID(&ulid)
 	if err != nil {

--- a/mock/util/ulid_generator_mock.go
+++ b/mock/util/ulid_generator_mock.go
@@ -6,7 +6,19 @@ import (
 	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
-// GenerateULID ULID生成処理を固定値でモックした関数
-func GenerateULID() ulid.ULID {
+// IULIDGenerator ULID生成処理のインターフェース
+type IULIDGenerator interface {
+	Generate() ulid.ULID
+}
+
+type ulidGenerator struct{}
+
+// NewULIDGenerator ULID生成処理のコンストラクタ
+func NewULIDGenerator() IULIDGenerator {
+	return &ulidGenerator{}
+}
+
+// Generate ULID生成処理を固定値でモックした関数
+func (ulidGenerator) Generate() ulid.ULID {
 	return tdULID.Room.ID.Valid
 }

--- a/test/application/room/create/interactor_test.go
+++ b/test/application/room/create/interactor_test.go
@@ -27,7 +27,7 @@ func TestHandle(t *testing.T) {
 	repository := mockDomainModel.NewMockIRepository(ctrl)
 	repository.EXPECT().Save(&tdDomain.Room.Entity.Valid).Return(nil)
 
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
+	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
 	interactor := application.NewInteractor(factory, repository)
 
 	tests := []struct {

--- a/test/domain/model/room/factory_test.go
+++ b/test/domain/model/room/factory_test.go
@@ -14,7 +14,7 @@ import (
 func TestCreate(t *testing.T) {
 	t.Parallel()
 
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
+	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
 
 	tests := []struct {
 		title     string

--- a/test/testdata/domain/room.go
+++ b/test/testdata/domain/room.go
@@ -38,7 +38,7 @@ type title struct {
 }
 
 func genRoom() domainModel.Room {
-	factory := domainModel.NewFactory(mockUtil.GenerateULID)
+	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
 
 	roomTitle := genRoomTitle()
 	room, err := factory.Create(&roomTitle)

--- a/util/ulid_generator.go
+++ b/util/ulid_generator.go
@@ -7,8 +7,20 @@ import (
 	"github.com/oklog/ulid"
 )
 
-// GenerateULID ランダムなULIDを生成する処理
-func GenerateULID() ulid.ULID {
+// IULIDGenerator ULID生成のインターフェース
+type IULIDGenerator interface {
+	Generate() ulid.ULID
+}
+
+type ulidGenerator struct{}
+
+// NewULIDGenerator ULID生成処理のコンストラクタ
+func NewULIDGenerator() IULIDGenerator {
+	return &ulidGenerator{}
+}
+
+// Generate ランダムなULIDを生成する処理
+func (ulidGenerator) Generate() ulid.ULID {
 	t := time.Now()
 	entropy := ulid.Monotonic(rand.New(rand.NewSource(t.UnixNano())), 0)
 	return ulid.MustNew(ulid.Timestamp(t), entropy)


### PR DESCRIPTION
## About
UILDGeneratorをコンストラクタで生成する
## Background
go/wireでDIする際に、Generate関数の直渡しが困難なため