### PR TITLE
refactor: テストデータを整理する

### DIFF
--- a/mock/util/ulid_generator_mock.go
+++ b/mock/util/ulid_generator_mock.go
@@ -20,5 +20,5 @@ func NewULIDGenerator() IULIDGenerator {
 
 // Generate ULID生成処理を固定値でモックした関数
 func (ulidGenerator) Generate() ulid.ULID {
-	return tdULID.Room.ID.Valid
+	return tdULID.Room.ID
 }

--- a/test/application/room/create/interactor_test.go
+++ b/test/application/room/create/interactor_test.go
@@ -11,7 +11,7 @@ import (
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/room"
 	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 

--- a/test/application/room/find_all/interactor_test.go
+++ b/test/application/room/find_all/interactor_test.go
@@ -9,7 +9,7 @@ import (
 	application "github.com/karamaru-alpha/chat-go-server/application/room/find_all"
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/room"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 )
 
 // TestHandle トークルームを全件取得するアプリケーションサービスのテスト

--- a/test/domain/model/room/entity_test.go
+++ b/test/domain/model/room/entity_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 )
 
 // TestNewRoom トークルームコンストラクタのテスト

--- a/test/domain/model/room/factory_test.go
+++ b/test/domain/model/room/factory_test.go
@@ -7,7 +7,7 @@ import (
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 )
 
 // TestCreate トークルーム生成処理を担うファクトリのテスト

--- a/test/domain/model/room/id_test.go
+++ b/test/domain/model/room/id_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
@@ -24,7 +24,7 @@ func TestNewID(t *testing.T) {
 	}{
 		{
 			title:     "【正常系】",
-			input:     &tdULID.Room.ID.Valid,
+			input:     &tdULID.Room.ID,
 			expected1: &tdDomain.Room.ID.Valid,
 			expected2: nil,
 		},

--- a/test/domain/model/room/title_test.go
+++ b/test/domain/model/room/title_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 

--- a/test/infrastructure/mysql/room/dto_test.go
+++ b/test/infrastructure/mysql/room/dto_test.go
@@ -8,7 +8,7 @@ import (
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 

--- a/test/infrastructure/mysql/room/repository_impl_test.go
+++ b/test/infrastructure/mysql/room/repository_impl_test.go
@@ -10,7 +10,7 @@ import (
 
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 

--- a/test/interfaces/controller/room/contoller_test.go
+++ b/test/interfaces/controller/room/contoller_test.go
@@ -14,7 +14,7 @@ import (
 	pb "github.com/karamaru-alpha/chat-go-server/interfaces/proto/pb"
 	mockCreateApplication "github.com/karamaru-alpha/chat-go-server/mock/application/room/create"
 	mockFindAllApplication "github.com/karamaru-alpha/chat-go-server/mock/application/room/find_all"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 

--- a/test/interfaces/controller/room/dto_test.go
+++ b/test/interfaces/controller/room/dto_test.go
@@ -8,7 +8,7 @@ import (
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 	controller "github.com/karamaru-alpha/chat-go-server/interfaces/controller/room"
 	pb "github.com/karamaru-alpha/chat-go-server/interfaces/proto/pb"
-	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 

--- a/test/testdata/domain/room/td.go
+++ b/test/testdata/domain/room/td.go
@@ -9,22 +9,6 @@ import (
 	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
-var Room = struct {
-	Entity entity
-	ID     id
-	Title  title
-}{
-	Entity: entity{
-		Valid: genRoom(),
-	},
-	ID: id{
-		Valid: genRoomID(),
-	},
-	Title: title{
-		Valid: genRoomTitle(),
-	},
-}
-
 type entity struct {
 	Valid domainModel.Room
 }
@@ -37,10 +21,26 @@ type title struct {
 	Valid domainModel.Title
 }
 
-func genRoom() domainModel.Room {
+var Room = struct {
+	Entity entity
+	ID     id
+	Title  title
+}{
+	Entity: entity{
+		Valid: genEntity(),
+	},
+	ID: id{
+		Valid: genID(),
+	},
+	Title: title{
+		Valid: genTitle(),
+	},
+}
+
+func genEntity() domainModel.Room {
 	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
 
-	roomTitle := genRoomTitle()
+	roomTitle := genTitle()
 	room, err := factory.Create(&roomTitle)
 	if err != nil {
 		log.Fatal(err)
@@ -49,8 +49,8 @@ func genRoom() domainModel.Room {
 	return *room
 }
 
-func genRoomID() domainModel.ID {
-	id, err := domainModel.NewID(&tdULID.Room.ID.Valid)
+func genID() domainModel.ID {
+	id, err := domainModel.NewID(&tdULID.Room.ID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func genRoomID() domainModel.ID {
 	return *id
 }
 
-func genRoomTitle() domainModel.Title {
+func genTitle() domainModel.Title {
 	title, err := domainModel.NewTitle(tdString.Room.Title.Valid)
 	if err != nil {
 		log.Fatal(err)

--- a/test/testdata/string/td.go
+++ b/test/testdata/string/td.go
@@ -4,11 +4,19 @@ import (
 	"strings"
 )
 
+type ulid struct {
+	Valid, Invalid string
+}
+
+type roomTitle struct {
+	Valid, TooShort, TooLong string
+}
+
 var Room = struct {
-	ID    roomID
+	ID    ulid
 	Title roomTitle
 }{
-	ID: roomID{
+	ID: ulid{
 		Valid:   "01D0KDBRASGD5HRSNDCKA0AH53",
 		Invalid: "invalid_ulid",
 	},
@@ -17,15 +25,4 @@ var Room = struct {
 		TooShort: ".",
 		TooLong:  strings.Repeat("a", 100),
 	},
-}
-
-type roomID struct {
-	Valid   string
-	Invalid string
-}
-
-type roomTitle struct {
-	Valid    string
-	TooShort string
-	TooLong  string
 }

--- a/test/testdata/ulid/td.go
+++ b/test/testdata/ulid/td.go
@@ -2,16 +2,12 @@ package testdata
 
 import (
 	"github.com/oklog/ulid"
+
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 
 var Room = struct {
-	ID roomID
+	ID ulid.ULID
 }{
-	ID: roomID{
-		Valid: ulid.MustParse("01D0KDBRASGD5HRSNDCKA0AH53"),
-	},
-}
-
-type roomID struct {
-	Valid ulid.ULID
+	ID: ulid.MustParse(tdString.Room.ID.Valid),
 }


### PR DESCRIPTION
## About
テストデータを整理する
## Background
今後多くのdomainが追加された際に肥大しそうだったので、パッケージを分けるなどした。
## Details
- `testdata/domain/`はドメインごとにパッケージを切る
- validしかないデータ郡はstructでまとめる