### PR TITLE
feat: メッセージのDB・ドメイン層

### DIFF
--- a/docker/mysql/db/init/001-ddl.sql
+++ b/docker/mysql/db/init/001-ddl.sql
@@ -10,9 +10,9 @@ COMMENT='トークルーム'
 DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `messages` (
-  `id`      CHAR(26)    NOT NULL        COMMENT 'メッセージULID',
-  `room_id` CHAR(26)    NOT NULL        COMMENT 'トークルームULID',
-  `body`    VARCHAR(64) NOT NULL        COMMENT 'メッセージ本文',
+  `id`      CHAR(26)    NOT NULL COMMENT 'メッセージULID',
+  `room_id` CHAR(26)    NOT NULL COMMENT 'トークルームULID',
+  `body`    VARCHAR(64) NOT NULL COMMENT 'メッセージ本文',
   PRIMARY KEY (`id`),
   CONSTRAINT fk_room_id
     FOREIGN KEY (`room_id`)

--- a/docker/mysql/db/init/001-ddl.sql
+++ b/docker/mysql/db/init/001-ddl.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS `messages`;
 DROP TABLE IF EXISTS `rooms`;
 
 CREATE TABLE IF NOT EXISTS `rooms` (
@@ -6,4 +7,17 @@ CREATE TABLE IF NOT EXISTS `rooms` (
   PRIMARY KEY (`id`))
 ENGINE=InnoDB
 COMMENT='トークルーム'
+DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `messages` (
+  `id`      CHAR(26)    NOT NULL        COMMENT 'メッセージULID',
+  `room_id` CHAR(26)    NOT NULL        COMMENT 'トークルームULID',
+  `body`    VARCHAR(64) NOT NULL        COMMENT 'メッセージ本文',
+  PRIMARY KEY (`id`),
+  CONSTRAINT fk_room_id
+    FOREIGN KEY (`room_id`)
+    REFERENCES rooms (`id`)
+    ON DELETE CASCADE)
+ENGINE=InnoDB
+COMMENT='メッセージ'
 DEFAULT CHARSET=utf8mb4;

--- a/docker/mysql/db/init/002-dml.sql
+++ b/docker/mysql/db/init/002-dml.sql
@@ -2,3 +2,6 @@ DELETE FROM `rooms`;
 INSERT INTO `rooms` (`id`, `title`) VALUES ("00000000000000000000000001", "ルームA");
 INSERT INTO `rooms` (`id`, `title`) VALUES ("00000000000000000000000002", "ルームB");
 INSERT INTO `rooms` (`id`, `title`) VALUES ("00000000000000000000000003", "ルームC");
+
+DELETE FROM `messages`;
+INSERT INTO `messages` (`id`, `room_id`, `body`) VALUES ("00000000000000000000000001", "00000000000000000000000001", "ルームAのメッセージ");

--- a/domain/model/message/body.go
+++ b/domain/model/message/body.go
@@ -1,0 +1,24 @@
+package message
+
+import (
+	"errors"
+	"unicode/utf8"
+)
+
+// Body メッセージ本文を表す値オブジェクト
+type Body string
+
+// NewBody メッセージ本文を表す値オブジェクトのコンストラクタ
+func NewBody(v string) (*Body, error) {
+
+	if v == "" {
+		return nil, errors.New("MessageBody is empty")
+	}
+
+	if utf8.RuneCountInString(v) == 0 || utf8.RuneCountInString(v) > 255 {
+		return nil, errors.New("MessageBody should be 1 to 255 characters")
+	}
+
+	body := Body(v)
+	return &body, nil
+}

--- a/domain/model/message/entity.go
+++ b/domain/model/message/entity.go
@@ -24,5 +24,5 @@ func NewMessage(id *ID, roomID *RoomID, body *Body) (*Message, error) {
 		return nil, errors.New("MessageBody is null")
 	}
 
-	return &Message{RoomID: *roomID, Body: *body}, nil
+	return &Message{ID: *id, RoomID: *roomID, Body: *body}, nil
 }

--- a/domain/model/message/entity.go
+++ b/domain/model/message/entity.go
@@ -1,0 +1,28 @@
+package message
+
+import "errors"
+
+// Message メッセージエンティティ
+type Message struct {
+	ID     ID
+	RoomID RoomID
+	Body   Body
+}
+
+// Message メッセージエンティティのコンストラクタ
+func NewMessage(id *ID, roomID *RoomID, body *Body) (*Message, error) {
+
+	if id == nil {
+		return nil, errors.New("MessageID is null")
+	}
+
+	if roomID == nil {
+		return nil, errors.New("MessageRoomID is null")
+	}
+
+	if body == nil {
+		return nil, errors.New("MessageBody is null")
+	}
+
+	return &Message{RoomID: *roomID, Body: *body}, nil
+}

--- a/domain/model/message/factory.go
+++ b/domain/model/message/factory.go
@@ -1,0 +1,32 @@
+package message
+
+import "github.com/karamaru-alpha/chat-go-server/util"
+
+// IFactory メッセージファクトリのインターフェース
+type IFactory interface {
+	Create(*RoomID, *Body) (*Message, error)
+}
+
+type factory struct {
+	ulidGenerator util.IULIDGenerator
+}
+
+// IFactory メッセージファクトリコンストラクタ
+func NewFactory(ulidGenerator util.IULIDGenerator) IFactory {
+	return &factory{
+		ulidGenerator,
+	}
+}
+
+// Create メッセージエンティティの生成処理を担うファクトリ
+func (f factory) Create(roomID *RoomID, body *Body) (*Message, error) {
+
+	ulid := f.ulidGenerator.Generate()
+
+	messageID, err := NewID(&ulid)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewMessage(messageID, roomID, body)
+}

--- a/domain/model/message/id.go
+++ b/domain/model/message/id.go
@@ -1,0 +1,21 @@
+package message
+
+import (
+	"errors"
+
+	"github.com/oklog/ulid"
+)
+
+// ID メッセージ識別子を表す値オブジェクト
+type ID ulid.ULID
+
+// NewID メッセージ識別子を表す値オブジェクトのコンストラクタ
+func NewID(v *ulid.ULID) (*ID, error) {
+
+	if v == nil {
+		return nil, errors.New("MessageID is null")
+	}
+
+	id := ID(*v)
+	return &id, nil
+}

--- a/domain/model/message/repository.go
+++ b/domain/model/message/repository.go
@@ -1,0 +1,7 @@
+package message
+
+// IRepository メッセージエンティティの永続化・再構築を実現するリポジトリ
+type IRepository interface {
+	Create(*Message) error
+	FindAll(*RoomID) (*[]Message, error)
+}

--- a/domain/model/message/room_id.go
+++ b/domain/model/message/room_id.go
@@ -1,0 +1,21 @@
+package message
+
+import (
+	"errors"
+
+	"github.com/oklog/ulid"
+)
+
+// RoomID メッセージが紐づくトークルームの識別子を表す値オブジェクト
+type RoomID ulid.ULID
+
+// NewRoomID メッセージが紐づくトークルームの識別子を表す値オブジェクトコンストラクタ
+func NewRoomID(v *ulid.ULID) (*RoomID, error) {
+
+	if v == nil {
+		return nil, errors.New("MessageRoomID is null")
+	}
+
+	roomID := RoomID(*v)
+	return &roomID, nil
+}

--- a/test/domain/model/message/body_test.go
+++ b/test/domain/model/message/body_test.go
@@ -1,0 +1,54 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
+)
+
+// TestNewBody メッセージ本文の値オブジェクトコンストラクタのテスト
+func TestNewBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body      string
+		input     string
+		expected1 *domainModel.Body
+		expected2 error
+	}{
+		{
+			body:      "【正常系】",
+			input:     tdString.Message.Body.Valid,
+			expected1: &tdDomain.Message.Body,
+			expected2: nil,
+		},
+		{
+			body:      "【異常系】本文が空",
+			input:     tdString.Message.Body.Empty,
+			expected1: nil,
+			expected2: errors.New("MessageBody is empty"),
+		},
+		{
+			body:      "【異常系】本文が長い",
+			input:     tdString.Message.Body.TooLong,
+			expected1: nil,
+			expected2: errors.New("MessageBody should be 1 to 255 characters"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+		t.Run("NewBody:"+td.body, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewBody(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/message/entity_test.go
+++ b/test/domain/model/message/entity_test.go
@@ -1,0 +1,70 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+)
+
+// TestNewMessage メッセージエンティティコンストラクタのテスト
+func TestNewMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		body      string
+		input1    *domainModel.ID
+		input2    *domainModel.RoomID
+		input3    *domainModel.Body
+		expected1 *domainModel.Message
+		expected2 error
+	}{
+		{
+			body:      "【正常系】",
+			input1:    &tdDomain.Message.ID,
+			input2:    &tdDomain.Message.RoomID,
+			input3:    &tdDomain.Message.Body,
+			expected1: &tdDomain.Message.Entity,
+			expected2: nil,
+		},
+		{
+			body:      "【異常系】IDがnil",
+			input1:    nil,
+			input2:    &tdDomain.Message.RoomID,
+			input3:    &tdDomain.Message.Body,
+			expected1: nil,
+			expected2: errors.New("MessageID is null"),
+		},
+		{
+			body:      "【異常系】RoomIDがnil",
+			input1:    &tdDomain.Message.ID,
+			input2:    nil,
+			input3:    &tdDomain.Message.Body,
+			expected1: nil,
+			expected2: errors.New("MessageRoomID is null"),
+		},
+		{
+			body:      "【異常系】Bodyがnil",
+			input1:    &tdDomain.Message.ID,
+			input2:    &tdDomain.Message.RoomID,
+			input3:    nil,
+			expected1: nil,
+			expected2: errors.New("MessageBody is null"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("NewMessage:"+td.body, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewMessage(td.input1, td.input2, td.input3)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/message/factory_test.go
+++ b/test/domain/model/message/factory_test.go
@@ -1,0 +1,46 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+)
+
+// TestCreate メッセージの生成処理を担うファクトリのテスト
+func TestCreate(t *testing.T) {
+	t.Parallel()
+
+	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
+
+	tests := []struct {
+		body      string
+		input1    *domainModel.RoomID
+		input2    *domainModel.Body
+		expected1 *domainModel.Message
+		expected2 error
+	}{
+		{
+			body:      "【正常系】",
+			input1:    &tdDomain.Message.RoomID,
+			input2:    &tdDomain.Message.Body,
+			expected1: &tdDomain.Message.Entity,
+			expected2: nil,
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("Create:"+td.body, func(t *testing.T) {
+
+			output1, output2 := factory.Create(td.input1, td.input2)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/message/id_test.go
+++ b/test/domain/model/message/id_test.go
@@ -1,0 +1,50 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
+)
+
+// TestNewID メッセージ識別子を表す値オブジェクトコンストラクタのテスト
+func TestNewID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title     string
+		input     *ulid.ULID
+		expected1 *domainModel.ID
+		expected2 error
+	}{
+		{
+			title:     "【正常系】",
+			input:     &tdULID.Message.ID,
+			expected1: &tdDomain.Message.ID,
+			expected2: nil,
+		},
+		{
+			title:     "【異常系】引数がnil",
+			input:     nil,
+			expected1: nil,
+			expected2: errors.New("MessageID is null"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("NewID:"+td.title, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewID(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/domain/model/message/room_id_test.go
+++ b/test/domain/model/message/room_id_test.go
@@ -1,0 +1,50 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
+)
+
+// TestNewRoomID メッセージが紐づくトークルームの識別子を表す値オブジェクトコンストラクタのテスト
+func TestNewRoomID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title     string
+		input     *ulid.ULID
+		expected1 *domainModel.RoomID
+		expected2 error
+	}{
+		{
+			title:     "【正常系】",
+			input:     &tdULID.Room.ID,
+			expected1: &tdDomain.Message.RoomID,
+			expected2: nil,
+		},
+		{
+			title:     "【異常系】引数がnil",
+			input:     nil,
+			expected1: nil,
+			expected2: errors.New("MessageRoomID is null"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("NewRoomID:"+td.title, func(t *testing.T) {
+
+			output1, output2 := domainModel.NewRoomID(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/testdata/domain/message/td.go
+++ b/test/testdata/domain/message/td.go
@@ -1,0 +1,63 @@
+package testdata
+
+import (
+	"log"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
+	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
+)
+
+// Message メッセージエンティティのテストデータ
+var Message = struct {
+	Entity domainModel.Message
+	ID     domainModel.ID
+	RoomID domainModel.RoomID
+	Body   domainModel.Body
+}{
+	Entity: genEntity(),
+	ID:     genID(),
+	RoomID: genRoomID(),
+	Body:   genBody(),
+}
+
+func genEntity() domainModel.Message {
+	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
+
+	roomID := genRoomID()
+	body := genBody()
+	message, err := factory.Create(&roomID, &body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *message
+}
+
+func genID() domainModel.ID {
+	id, err := domainModel.NewID(&tdULID.Message.ID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *id
+}
+
+func genRoomID() domainModel.RoomID {
+	roomID, err := domainModel.NewRoomID(&tdULID.Room.ID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *roomID
+}
+
+func genBody() domainModel.Body {
+	body, err := domainModel.NewBody(tdString.Message.Body.Valid)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return *body
+}

--- a/test/testdata/string/td.go
+++ b/test/testdata/string/td.go
@@ -12,6 +12,11 @@ type roomTitle struct {
 	Valid, TooShort, TooLong string
 }
 
+type messageBody struct {
+	Valid, Empty, TooLong string
+}
+
+// Room トークルームにまつわる文字列のテストデータ
 var Room = struct {
 	ID    ulid
 	Title roomTitle
@@ -24,5 +29,21 @@ var Room = struct {
 		Valid:    "valid_title",
 		TooShort: ".",
 		TooLong:  strings.Repeat("a", 100),
+	},
+}
+
+// Message メッセージにまつわる文字列のテストデータ
+var Message = struct {
+	ID   ulid
+	Body messageBody
+}{
+	ID: ulid{
+		Valid:   "01D0KDBRASGD5HRSNDCKA0AH53",
+		Invalid: "invalid_ulid",
+	},
+	Body: messageBody{
+		Valid:   "valid_message_body",
+		Empty:   "",
+		TooLong: strings.Repeat("a", 256),
 	},
 }

--- a/test/testdata/ulid/td.go
+++ b/test/testdata/ulid/td.go
@@ -6,8 +6,16 @@ import (
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 
+// Room ルームエンティティ生成に必要なULIDのテストデータ
 var Room = struct {
 	ID ulid.ULID
 }{
 	ID: ulid.MustParse(tdString.Room.ID.Valid),
+}
+
+// Message メッセージエンティティ生成に必要なULIDのテストデータ
+var Message = struct {
+	ID ulid.ULID
+}{
+	ID: ulid.MustParse(tdString.Message.ID.Valid),
 }


### PR DESCRIPTION
## About
メッセージのDB・ドメイン層実装

## Background
チャット機能で用いるため

## Details
- メッセージは「ID / RoomID / Body(0<x<256)」を持つ
- 外部キー制約で、親Roomが削除された場合紐づくメッセージも削除

## Preview
<img width="815" alt="スクリーンショット 2021-04-06 17 18 14" src="https://user-images.githubusercontent.com/38310693/113680673-1436e900-96fc-11eb-9a4a-f542adbab45c.png">
<img width="386" alt="スクリーンショット 2021-04-06 17 18 41" src="https://user-images.githubusercontent.com/38310693/113680732-23b63200-96fc-11eb-8eb9-a6b9c1ab7fa2.png">

