### PR TITLE
refactor: コンストラクタを経由せずドメインテストデータを作成

### DIFF
--- a/test/testdata/domain/message/td.go
+++ b/test/testdata/domain/message/td.go
@@ -1,15 +1,12 @@
 package testdata
 
 import (
-	"log"
-
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
-	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
-// Message メッセージエンティティのテストデータ
+// Message メッセージエンティティにまつわるテストデータ
 var Message = struct {
 	Entity domainModel.Message
 	ID     domainModel.ID
@@ -23,41 +20,21 @@ var Message = struct {
 }
 
 func genEntity() domainModel.Message {
-	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
-
-	roomID := genRoomID()
-	body := genBody()
-	message, err := factory.Create(&roomID, &body)
-	if err != nil {
-		log.Fatal(err)
+	return domainModel.Message{
+		ID:     genID(),
+		RoomID: genRoomID(),
+		Body:   genBody(),
 	}
-
-	return *message
 }
 
 func genID() domainModel.ID {
-	id, err := domainModel.NewID(&tdULID.Message.ID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return *id
+	return domainModel.ID(tdULID.Message.ID)
 }
 
 func genRoomID() domainModel.RoomID {
-	roomID, err := domainModel.NewRoomID(&tdULID.Room.ID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return *roomID
+	return domainModel.RoomID(tdULID.Room.ID)
 }
 
 func genBody() domainModel.Body {
-	body, err := domainModel.NewBody(tdString.Message.Body.Valid)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return *body
+	return domainModel.Body(tdString.Message.Body.Valid)
 }

--- a/test/testdata/domain/room/td.go
+++ b/test/testdata/domain/room/td.go
@@ -1,14 +1,12 @@
 package testdata
 
 import (
-	"log"
-
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
-	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 	tdULID "github.com/karamaru-alpha/chat-go-server/test/testdata/ulid"
 )
 
+// Room トークルームエンティティにまつわるテストデータ
 var Room = struct {
 	Entity domainModel.Room
 	ID     domainModel.ID
@@ -20,31 +18,16 @@ var Room = struct {
 }
 
 func genEntity() domainModel.Room {
-	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
-
-	roomTitle := genTitle()
-	room, err := factory.Create(&roomTitle)
-	if err != nil {
-		log.Fatal(err)
+	return domainModel.Room{
+		ID:    genID(),
+		Title: genTitle(),
 	}
-
-	return *room
 }
 
 func genID() domainModel.ID {
-	id, err := domainModel.NewID(&tdULID.Room.ID)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return *id
+	return domainModel.ID(tdULID.Room.ID)
 }
 
 func genTitle() domainModel.Title {
-	title, err := domainModel.NewTitle(tdString.Room.Title.Valid)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return *title
+	return domainModel.Title(tdString.Room.Title.Valid)
 }


### PR DESCRIPTION
## About
コンストラクタを経由せずドメインテストデータを作成
## Background
テストデータ作成も独自コンストラクタ経由で行っていたため、そのコンストラクタに欠陥があってもテストが通ってしまっていた。
## Details
ドメインテストデータを作成する際は、愚直に値を構造体に入れる