### PR TITLE
feat: トークルームの名前の重複をチェックするドメインサービスを実装する

### DIFF
--- a/application/room/create/interactor.go
+++ b/application/room/create/interactor.go
@@ -1,19 +1,24 @@
 package room
 
 import (
+	"errors"
+
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	domainService "github.com/karamaru-alpha/chat-go-server/domain/service/room"
 )
 
 type interactor struct {
-	factory    domainModel.IFactory
-	repository domainModel.IRepository
+	factory       domainModel.IFactory
+	repository    domainModel.IRepository
+	domainService domainService.IDomainService
 }
 
 // NewInteractor トークルームを新規作成するアプリケーションサービスのコンストラクタ
-func NewInteractor(factory domainModel.IFactory, repository domainModel.IRepository) IInputPort {
+func NewInteractor(f domainModel.IFactory, r domainModel.IRepository, s domainService.IDomainService) IInputPort {
 	return &interactor{
-		factory,
-		repository,
+		factory:       f,
+		repository:    r,
+		domainService: s,
 	}
 }
 
@@ -22,17 +27,25 @@ func (i interactor) Handle(input InputData) OutputData {
 
 	roomTitle, err := domainModel.NewTitle(input.Title)
 	if err != nil {
-		return OutputData{nil, err}
+		return OutputData{Err: err}
 	}
 
 	room, err := i.factory.Create(roomTitle)
 	if err != nil {
-		return OutputData{nil, err}
+		return OutputData{Err: err}
+	}
+
+	isDup, err := i.domainService.Exists(room)
+	if err != nil {
+		return OutputData{Err: err}
+	}
+	if isDup {
+		return OutputData{Err: errors.New("RoomTitle is duplicated")}
 	}
 
 	if err = i.repository.Save(room); err != nil {
-		return OutputData{nil, err}
+		return OutputData{Err: err}
 	}
 
-	return OutputData{room, nil}
+	return OutputData{Room: room}
 }

--- a/di/room/wire.go
+++ b/di/room/wire.go
@@ -8,6 +8,7 @@ import (
 	createApplication "github.com/karamaru-alpha/chat-go-server/application/room/create"
 	findAllApplication "github.com/karamaru-alpha/chat-go-server/application/room/find_all"
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	domainService "github.com/karamaru-alpha/chat-go-server/domain/service/room"
 	"github.com/karamaru-alpha/chat-go-server/infrastructure/mysql"
 	repositoryImpl "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
 	controller "github.com/karamaru-alpha/chat-go-server/interfaces/controller/room"
@@ -23,6 +24,7 @@ func DI() pb.RoomServicesServer {
 		findAllApplication.NewInteractor,
 		repositoryImpl.NewRepositoryImpl,
 		domainModel.NewFactory,
+		domainService.NewDomainService,
 		util.NewULIDGenerator,
 		mysql.ConnectGorm,
 	)

--- a/di/room/wire_gen.go
+++ b/di/room/wire_gen.go
@@ -6,12 +6,13 @@
 package room
 
 import (
-	room3 "github.com/karamaru-alpha/chat-go-server/application/room/create"
-	room4 "github.com/karamaru-alpha/chat-go-server/application/room/find_all"
+	room4 "github.com/karamaru-alpha/chat-go-server/application/room/create"
+	room5 "github.com/karamaru-alpha/chat-go-server/application/room/find_all"
 	"github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	room3 "github.com/karamaru-alpha/chat-go-server/domain/service/room"
 	"github.com/karamaru-alpha/chat-go-server/infrastructure/mysql"
 	room2 "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/room"
-	room5 "github.com/karamaru-alpha/chat-go-server/interfaces/controller/room"
+	room6 "github.com/karamaru-alpha/chat-go-server/interfaces/controller/room"
 	"github.com/karamaru-alpha/chat-go-server/interfaces/proto/pb"
 	"github.com/karamaru-alpha/chat-go-server/util"
 )
@@ -24,8 +25,9 @@ func DI() proto.RoomServicesServer {
 	iFactory := room.NewFactory(iulidGenerator)
 	db := mysql.ConnectGorm()
 	iRepository := room2.NewRepositoryImpl(db)
-	iInputPort := room3.NewInteractor(iFactory, iRepository)
-	roomIInputPort := room4.NewInteractor(iRepository)
-	roomServicesServer := room5.NewController(iInputPort, roomIInputPort)
+	iDomainService := room3.NewDomainService(iRepository)
+	iInputPort := room4.NewInteractor(iFactory, iRepository, iDomainService)
+	roomIInputPort := room5.NewInteractor(iRepository)
+	roomServicesServer := room6.NewController(iInputPort, roomIInputPort)
 	return roomServicesServer
 }

--- a/domain/model/room/repository.go
+++ b/domain/model/room/repository.go
@@ -4,4 +4,5 @@ package room
 type IRepository interface {
 	Save(*Room) error
 	FindAll() (*[]Room, error)
+	FindByTitle(*Title) (*Room, error)
 }

--- a/domain/service/room/service.go
+++ b/domain/service/room/service.go
@@ -1,0 +1,29 @@
+package room
+
+import (
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+// IDomainService ドメインサービスのインターフェース
+type IDomainService interface {
+	Exists(*domainModel.Room) (bool, error)
+}
+
+type domainService struct {
+	repository domainModel.IRepository
+}
+
+// NewDomainService ドメインサービスのコンストラクタ
+func NewDomainService(r domainModel.IRepository) IDomainService {
+	return &domainService{
+		repository: r,
+	}
+}
+
+// Exists トークルーム重複判定のドメインサービス
+func (s domainService) Exists(room *domainModel.Room) (bool, error) {
+
+	room, err := s.repository.FindByTitle(&room.Title)
+
+	return room != nil, err
+}

--- a/infrastructure/mysql/room/repository_impl.go
+++ b/infrastructure/mysql/room/repository_impl.go
@@ -38,3 +38,17 @@ func (r repositoryImpl) FindAll() (*[]domainModel.Room, error) {
 
 	return ToEntities(&dtos)
 }
+
+// FindByTitle トークルームをタイトルから一件取得する
+func (r repositoryImpl) FindByTitle(title *domainModel.Title) (*domainModel.Room, error) {
+	var dto Room
+
+	if err := r.db.Where("title = ?", string(*title)).First(&dto).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return ToEntity(&dto)
+}

--- a/mock/domain/model/room/repository_mock.go
+++ b/mock/domain/model/room/repository_mock.go
@@ -49,6 +49,21 @@ func (mr *MockIRepositoryMockRecorder) FindAll() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockIRepository)(nil).FindAll))
 }
 
+// FindByTitle mocks base method.
+func (m *MockIRepository) FindByTitle(arg0 *room.Title) (*room.Room, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByTitle", arg0)
+	ret0, _ := ret[0].(*room.Room)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByTitle indicates an expected call of FindByTitle.
+func (mr *MockIRepositoryMockRecorder) FindByTitle(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByTitle", reflect.TypeOf((*MockIRepository)(nil).FindByTitle), arg0)
+}
+
 // Save mocks base method.
 func (m *MockIRepository) Save(arg0 *room.Room) error {
 	m.ctrl.T.Helper()

--- a/test/application/room/create/interactor_test.go
+++ b/test/application/room/create/interactor_test.go
@@ -9,6 +9,7 @@ import (
 
 	application "github.com/karamaru-alpha/chat-go-server/application/room/create"
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	domainService "github.com/karamaru-alpha/chat-go-server/domain/service/room"
 	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/room"
 	mockUtil "github.com/karamaru-alpha/chat-go-server/mock/util"
 	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
@@ -25,24 +26,38 @@ func TestHandle(t *testing.T) {
 
 	// reposityをモック
 	repository := mockDomainModel.NewMockIRepository(ctrl)
-	repository.EXPECT().Save(&tdDomain.Room.Entity).Return(nil)
-
 	factory := domainModel.NewFactory(mockUtil.NewULIDGenerator())
-	interactor := application.NewInteractor(factory, repository)
+	domainService := domainService.NewDomainService(repository)
+	interactor := application.NewInteractor(factory, repository, domainService)
 
 	tests := []struct {
 		title    string
+		before   func()
 		input    application.InputData
 		expected application.OutputData
 	}{
 		{
 			title: "【正常系】",
+			before: func() {
+				repository.EXPECT().Save(&tdDomain.Room.Entity).Return(nil)
+				repository.EXPECT().FindByTitle(&tdDomain.Room.Title).Return(nil, nil)
+			},
 			input: application.InputData{
 				Title: tdString.Room.Title.Valid,
 			},
 			expected: application.OutputData{
 				Room: &tdDomain.Room.Entity,
 				Err:  nil,
+			},
+		},
+		{
+			title: "【異常系】タイトルが空文字列",
+			input: application.InputData{
+				Title: "",
+			},
+			expected: application.OutputData{
+				Room: nil,
+				Err:  errors.New("RoomTitle is null"),
 			},
 		},
 		{
@@ -65,12 +80,30 @@ func TestHandle(t *testing.T) {
 				Err:  errors.New("RoomTitle should be Three to twenty characters"),
 			},
 		},
+		{
+			title: "【異常系】タイトルが重複している",
+			before: func() {
+				repository.EXPECT().FindByTitle(&tdDomain.Room.Title).Return(&tdDomain.Room.Entity, nil)
+			},
+			input: application.InputData{
+				Title: tdString.Room.Title.Valid,
+			},
+			expected: application.OutputData{
+				Room: nil,
+				Err:  errors.New("RoomTitle is duplicated"),
+			},
+		},
 	}
 
 	for _, td := range tests {
 		td := td
 
 		t.Run("Handle:"+td.title, func(t *testing.T) {
+
+			if td.before != nil {
+				td.before()
+			}
+
 			output := interactor.Handle(td.input)
 			assert.Equal(t, td.expected, output)
 		})

--- a/test/application/room/find_all/interactor_test.go
+++ b/test/application/room/find_all/interactor_test.go
@@ -22,16 +22,18 @@ func TestHandle(t *testing.T) {
 
 	// reposityをモック
 	repository := mockDomainModel.NewMockIRepository(ctrl)
-	repository.EXPECT().FindAll().Return(&[]domainModel.Room{tdDomain.Room.Entity}, nil)
-
 	interactor := application.NewInteractor(repository)
 
 	tests := []struct {
 		title    string
+		before   func()
 		expected application.OutputData
 	}{
 		{
 			title: "【正常系】",
+			before: func() {
+				repository.EXPECT().FindAll().Return(&[]domainModel.Room{tdDomain.Room.Entity}, nil)
+			},
 			expected: application.OutputData{
 				Rooms: &[]domainModel.Room{tdDomain.Room.Entity},
 				Err:   nil,
@@ -41,6 +43,8 @@ func TestHandle(t *testing.T) {
 
 	for _, td := range tests {
 		td := td
+
+		td.before()
 
 		t.Run("Handle:"+td.title, func(t *testing.T) {
 			output := interactor.Handle()

--- a/test/domain/service/room/service_test.go
+++ b/test/domain/service/room/service_test.go
@@ -1,0 +1,67 @@
+package room
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+	domainService "github.com/karamaru-alpha/chat-go-server/domain/service/room"
+	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/room"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
+)
+
+// TestExists トークルームの重複チェックを担うドメインサービスのテスト
+func TestExists(t *testing.T) {
+	t.Parallel()
+
+	// go-mockの開始
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// reposityをモック
+	repository := mockDomainModel.NewMockIRepository(ctrl)
+	domainService := domainService.NewDomainService(repository)
+
+	tests := []struct {
+		title     string
+		before    func()
+		input     *domainModel.Room
+		expected1 bool
+		expected2 error
+	}{
+		{
+			title: "【正常系】該当タイトルのトークルームが存在しない",
+			before: func() {
+				repository.EXPECT().FindByTitle(&tdDomain.Room.Title).Return(nil, nil)
+			},
+			input:     &tdDomain.Room.Entity,
+			expected1: false,
+			expected2: nil,
+		},
+		{
+			title: "【正常系】該当タイトルのトークルームが存在する",
+			before: func() {
+				repository.EXPECT().FindByTitle(&tdDomain.Room.Title).Return(&tdDomain.Room.Entity, nil)
+			},
+			input:     &tdDomain.Room.Entity,
+			expected1: true,
+			expected2: nil,
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("Exists:"+td.title, func(t *testing.T) {
+
+			td.before()
+
+			output1, output2 := domainService.Exists(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/infrastructure/mysql/room/repository_impl_test.go
+++ b/test/infrastructure/mysql/room/repository_impl_test.go
@@ -62,6 +62,26 @@ func TestFindAll(t *testing.T) {
 	test.TeardownTest(t)
 }
 
+// TestFindByTitle トークルームをタイトルから一件取得・再構築する処理のテスト
+func TestFindByTitle(t *testing.T) {
+	// モックの作成
+	test := repositoryImplTester{}
+	test.setupTest(t)
+
+	test.mock.ExpectQuery("SELECT").WithArgs(tdString.Room.Title.Valid).WillReturnRows(sqlmock.NewRows([]string{"id", "title"}).AddRow(tdString.Room.ID.Valid, tdString.Room.Title.Valid))
+
+	// 実行
+	output, err := test.repositoryImpl.FindByTitle(&tdDomain.Room.Title)
+	assert.NoError(t, err)
+
+	assert.Equal(t, &tdDomain.Room.Entity, output)
+
+	err = test.mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+
+	test.TeardownTest(t)
+}
+
 func (r *repositoryImplTester) setupTest(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)


### PR DESCRIPTION
## About
トークルームの名前の重複をチェックするドメインサービスを実装する
## Background
トークルームのタイトルはユニークである。
DBのユニークに丸投げするのはよくない&重複チェックはエンティティにもたせると不自然であるから、ドメインサービスを実装する。
## Details
- `FindByTitle(*domainModel.TItle) (*domainModel.Room, error)`を実装
- ドメインサービス`Exists`では、エンティティを受け取りそれが重複していないか確認する。(現状はタイトルで判定)

