### PR TITLE
refactor: スライスの要素数が明らかな場合はcapを明示的に確保

### DIFF
--- a/infrastructure/mysql/room/dto.go
+++ b/infrastructure/mysql/room/dto.go
@@ -42,8 +42,7 @@ func ToEntity(dto *Room) (*domain.Room, error) {
 }
 
 func ToEntities(dtos *[]Room) (*[]domain.Room, error) {
-	var entities []domain.Room
-
+	entities := make([]domain.Room, 0, len(*dtos))
 	for _, v := range *dtos {
 		entity, err := ToEntity(&v)
 		if err != nil {
@@ -51,6 +50,5 @@ func ToEntities(dtos *[]Room) (*[]domain.Room, error) {
 		}
 		entities = append(entities, *entity)
 	}
-
 	return &entities, nil
 }

--- a/interfaces/controller/room/dto.go
+++ b/interfaces/controller/room/dto.go
@@ -17,7 +17,7 @@ func ToProto(entity *domain.Room) *pb.Room {
 
 // ToProtos トークルームエンティティのスライスをｇRPCの型に変換
 func ToProtos(entities *[]domain.Room) []*pb.Room {
-	var rooms []*pb.Room
+	rooms := make([]*pb.Room, 0, len(*entities))
 	for _, v := range *entities {
 		rooms = append(rooms, ToProto(&v))
 	}


### PR DESCRIPTION
## About
スライスの要素数が明らかな場合はcapを明示的に確保
## Background
スライスはcap指定しないとほぼ倍々で増え、パフォーマンスに問題がでるため。
## Details
`make([]T, length, cap) []T`関数を使用