### PR TITLE
feat: メッセージリポジトリの実装クラス

### DIFF
--- a/infrastructure/mysql/message/dto.go
+++ b/infrastructure/mysql/message/dto.go
@@ -1,0 +1,83 @@
+package message
+
+import (
+	"github.com/oklog/ulid"
+
+	domain "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	roomDomain "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+// Message メッセージエンティティにDB属性を加えたDTO
+type Message struct {
+	ID     string `gorm:"primary_key"`
+	RoomID string
+	Body   string
+}
+
+// ToDTO メッセージエンティティをDB情報を持った構造体に変換する
+func ToDTO(entity *domain.Message) *Message {
+	if entity == nil {
+		return nil
+	}
+
+	return &Message{
+		ID:     ulid.ULID(entity.ID).String(),
+		RoomID: ulid.ULID(entity.RoomID).String(),
+		Body:   string(entity.Body),
+	}
+}
+
+// ToEntity DB情報を持った構造体からメッセージエンティティに変換する
+func ToEntity(dto *Message) (*domain.Message, error) {
+	if dto == nil {
+		return nil, nil
+	}
+
+	parsedULID, err := ulid.Parse(dto.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	entityID, err := domain.NewID(&parsedULID)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedRoomULID, err := ulid.Parse(dto.RoomID)
+	if err != nil {
+		return nil, err
+	}
+
+	entityRoomID, err := roomDomain.NewID(&parsedRoomULID)
+	if err != nil {
+		return nil, err
+	}
+
+	entityBody, err := domain.NewBody(dto.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return domain.NewMessage(
+		entityID,
+		entityRoomID,
+		entityBody,
+	)
+}
+
+// ToEntity DB情報を持った構造体のスライスをエンティティに変換する
+func ToEntities(dtos *[]Message) (*[]domain.Message, error) {
+	if dtos == nil {
+		return nil, nil
+	}
+
+	entities := make([]domain.Message, 0, len(*dtos))
+	for _, v := range *dtos {
+		entity, err := ToEntity(&v)
+		if err != nil {
+			return nil, err
+		}
+		entities = append(entities, *entity)
+	}
+	return &entities, nil
+}

--- a/infrastructure/mysql/message/repository_impl.go
+++ b/infrastructure/mysql/message/repository_impl.go
@@ -1,0 +1,40 @@
+package message
+
+import (
+	"errors"
+
+	"github.com/jinzhu/gorm"
+	"github.com/oklog/ulid"
+
+	messageDomain "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	roomDomain "github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
+
+type repositoryImpl struct {
+	db *gorm.DB
+}
+
+// NewRepositoryImpl メッセージの永続化・再構築を行うRepositoryImplのコンストラクタ
+func NewRepositoryImpl(db *gorm.DB) messageDomain.IRepository {
+	return &repositoryImpl{
+		db,
+	}
+}
+
+// Create メッセージの永続化を行う
+func (r repositoryImpl) Create(entity *messageDomain.Message) error {
+	dto := ToDTO(entity)
+	return r.db.Create(dto).Error
+}
+
+// FindAll 特定トークルームのメッセージ一覧を取得する
+func (r repositoryImpl) FindAll(roomID *roomDomain.ID) (*[]messageDomain.Message, error) {
+	var dtos []Message
+	if err := r.db.Where("room_id = ?", ulid.ULID(*roomID).String()).Find(&dtos).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return ToEntities(&dtos)
+}

--- a/infrastructure/mysql/room/dto.go
+++ b/infrastructure/mysql/room/dto.go
@@ -12,6 +12,7 @@ type Room struct {
 	Title string
 }
 
+// ToDTO トークルームエンティティをDB情報を持ったDTOに変換する
 func ToDTO(entity *domain.Room) *Room {
 	if entity == nil {
 		return nil
@@ -23,6 +24,7 @@ func ToDTO(entity *domain.Room) *Room {
 	}
 }
 
+// ToEntity DB情報を持った構造体をトークルームエンティティに変換する
 func ToEntity(dto *Room) (*domain.Room, error) {
 	if dto == nil {
 		return nil, nil
@@ -49,6 +51,7 @@ func ToEntity(dto *Room) (*domain.Room, error) {
 	)
 }
 
+// ToEntities DB情報を持った複数の構造体をトークルームエンティティに変換する
 func ToEntities(dtos *[]Room) (*[]domain.Room, error) {
 	if dtos == nil {
 		return nil, nil

--- a/test/infrastructure/mysql/message/dto_test.go
+++ b/test/infrastructure/mysql/message/dto_test.go
@@ -1,0 +1,129 @@
+package message
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	messageDomain "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/message"
+	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
+)
+
+// TestToDTO メッセージエンティティをDB情報を持った構造体に変換する処理のテスト
+func TestToDTO(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title    string
+		input    *messageDomain.Message
+		expected *infra.Message
+	}{
+		{
+			title: "【正常系】メッセージエンティティをDB情報を持った構造体に変換",
+			input: &tdDomain.Message.Entity,
+			expected: &infra.Message{
+				ID:     tdString.Message.ID.Valid,
+				RoomID: tdString.Room.ID.Valid,
+				Body:   tdString.Message.Body.Valid,
+			},
+		},
+		{
+			title:    "【正常系】nilが来たらnilを返す",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("ToDTO:"+td.title, func(t *testing.T) {
+			output := infra.ToDTO(td.input)
+
+			assert.Equal(t, td.expected, output)
+		})
+	}
+}
+
+// TestToEntity DB情報を持ったトークルームDTOをEntityに変換する処理のテスト
+func TestToEntity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title     string
+		input     *infra.Message
+		expected1 *messageDomain.Message
+		expected2 error
+	}{
+		{
+			title: "【正常系】DB情報を持った構造体をメッセージエンティティに変換",
+			input: &infra.Message{
+				ID:     tdString.Message.ID.Valid,
+				RoomID: tdString.Room.ID.Valid,
+				Body:   tdString.Message.Body.Valid,
+			},
+			expected1: &tdDomain.Message.Entity,
+			expected2: nil,
+		},
+		{
+			title:     "【正常系】nilが来たらnilを返す",
+			input:     nil,
+			expected1: nil,
+			expected2: nil,
+		},
+		{
+			title: "【異常系】IDが不正値",
+			input: &infra.Message{
+				ID:     tdString.Message.ID.Invalid,
+				RoomID: tdString.Room.ID.Valid,
+				Body:   tdString.Message.Body.Valid,
+			},
+			expected1: nil,
+			expected2: errors.New("ulid: bad data size when unmarshaling"),
+		},
+		{
+			title: "【異常系】RoomIDが不正値",
+			input: &infra.Message{
+				ID:     tdString.Message.ID.Valid,
+				RoomID: tdString.Room.ID.Invalid,
+				Body:   tdString.Message.Body.Valid,
+			},
+			expected1: nil,
+			expected2: errors.New("ulid: bad data size when unmarshaling"),
+		},
+		{
+			title: "【異常系】Bodyが不正値(empty)",
+			input: &infra.Message{
+				ID:     tdString.Message.ID.Valid,
+				RoomID: tdString.Room.ID.Valid,
+				Body:   tdString.Message.Body.Empty,
+			},
+			expected1: nil,
+			expected2: errors.New("MessageBody is empty"),
+		},
+		{
+			title: "【異常系】Bodyが不正値(long)",
+			input: &infra.Message{
+				ID:     tdString.Message.ID.Valid,
+				RoomID: tdString.Room.ID.Valid,
+				Body:   tdString.Message.Body.TooLong,
+			},
+			expected1: nil,
+			expected2: errors.New("MessageBody should be 1 to 255 characters"),
+		},
+	}
+
+	for _, td := range tests {
+		td := td
+
+		t.Run("ToEntity:"+td.title, func(t *testing.T) {
+			output1, output2 := infra.ToEntity(td.input)
+
+			assert.Equal(t, td.expected1, output1)
+			assert.Equal(t, td.expected2, output2)
+		})
+	}
+}

--- a/test/infrastructure/mysql/message/repository_impl_test.go
+++ b/test/infrastructure/mysql/message/repository_impl_test.go
@@ -1,0 +1,87 @@
+package message
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+
+	domain "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	infra "github.com/karamaru-alpha/chat-go-server/infrastructure/mysql/message"
+	tdMessageDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
+	tdRoomDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/room"
+	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
+)
+
+type repositoryImplTester struct {
+	repositoryImpl domain.IRepository
+	db             *gorm.DB
+	mock           sqlmock.Sqlmock
+}
+
+// TestCreate メッセージを永続化させる処理のテスト
+func TestSave(t *testing.T) {
+	t.Parallel()
+
+	// モックの作成
+	tester := repositoryImplTester{}
+	tester.setupTest(t)
+
+	tester.mock.ExpectBegin()
+	tester.mock.ExpectExec(
+		regexp.QuoteMeta("INSERT INTO `messages` (`id`,`room_id`,`body`)"),
+	).WithArgs(tdString.Message.ID.Valid, tdString.Room.ID.Valid, tdString.Message.Body.Valid).WillReturnResult(sqlmock.NewResult(1, 1))
+	tester.mock.ExpectCommit()
+
+	// 実行
+	err := tester.repositoryImpl.Create(&tdMessageDomain.Message.Entity)
+	assert.NoError(t, err)
+
+	err = tester.mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+
+	tester.TeardownTest(t)
+}
+
+// TestFindAll 該当トークルームにあるメッセージの全件検索+再構築を行う処理のテスト
+func TestFindAll(t *testing.T) {
+	t.Parallel()
+
+	// モックの作成
+	test := repositoryImplTester{}
+	test.setupTest(t)
+
+	test.mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "room_id", "body"}).AddRow(tdString.Message.ID.Valid, tdString.Room.ID.Valid, tdString.Message.Body.Valid))
+
+	// 実行
+	output, err := test.repositoryImpl.FindAll(&tdRoomDomain.Room.ID)
+	assert.NoError(t, err)
+
+	assert.Equal(t, &[]domain.Message{tdMessageDomain.Message.Entity}, output)
+
+	err = test.mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+
+	test.TeardownTest(t)
+}
+
+func (r *repositoryImplTester) setupTest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+
+	gormDB, err := gorm.Open("mysql", db)
+	assert.NoError(t, err)
+	gormDB.LogMode(true)
+
+	repositoryImpl := infra.NewRepositoryImpl(gormDB)
+
+	r.db = gormDB
+	r.mock = mock
+	r.repositoryImpl = repositoryImpl
+}
+
+func (r *repositoryImplTester) TeardownTest(t *testing.T) {
+	r.db.Close()
+}

--- a/test/infrastructure/mysql/room/dto_test.go
+++ b/test/infrastructure/mysql/room/dto_test.go
@@ -55,7 +55,7 @@ func TestToEntity(t *testing.T) {
 		expected2 error
 	}{
 		{
-			title:     "【正常系】DB情報を持った構造体をメッセージエンティティに変換",
+			title:     "【正常系】DB情報を持った構造体をトークルームエンティティに変換",
 			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.Valid},
 			expected1: &tdDomain.Room.Entity,
 			expected2: nil,
@@ -65,6 +65,18 @@ func TestToEntity(t *testing.T) {
 			input:     nil,
 			expected1: nil,
 			expected2: nil,
+		},
+		{
+			title:     "【異常系】IDが不正値",
+			input:     &infra.Room{ID: tdString.Room.ID.Invalid, Title: tdString.Room.Title.Valid},
+			expected1: nil,
+			expected2: errors.New("ulid: bad data size when unmarshaling"),
+		},
+		{
+			title:     "【異常系】タイトルが空文字列",
+			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: ""},
+			expected1: nil,
+			expected2: errors.New("RoomTitle is null"),
 		},
 		{
 			title:     "【異常系】タイトルが不正値(short)",

--- a/test/infrastructure/mysql/room/repository_impl_test.go
+++ b/test/infrastructure/mysql/room/repository_impl_test.go
@@ -22,6 +22,8 @@ type repositoryImplTester struct {
 
 // TestSave トークルームを永続化させる処理のテスト
 func TestSave(t *testing.T) {
+	t.Parallel()
+
 	// モックの作成
 	tester := repositoryImplTester{}
 	tester.setupTest(t)
@@ -44,6 +46,8 @@ func TestSave(t *testing.T) {
 
 // TestFindAll トークルームの全件検索+再構築を行う処理のテスト
 func TestFindAll(t *testing.T) {
+	t.Parallel()
+
 	// モックの作成
 	test := repositoryImplTester{}
 	test.setupTest(t)
@@ -64,6 +68,8 @@ func TestFindAll(t *testing.T) {
 
 // TestFind トークルームをIDから一件取得・再構築する処理のテスト
 func TestFind(t *testing.T) {
+	t.Parallel()
+
 	// モックの作成
 	test := repositoryImplTester{}
 	test.setupTest(t)
@@ -84,6 +90,8 @@ func TestFind(t *testing.T) {
 
 // TestFindByTitle トークルームをタイトルから一件取得・再構築する処理のテスト
 func TestFindByTitle(t *testing.T) {
+	t.Parallel()
+
 	// モックの作成
 	test := repositoryImplTester{}
 	test.setupTest(t)


### PR DESCRIPTION
## About
メッセージリポジトリの実装クラス

## Details
- `infrastructure/mysql/room/`にメッセージリポジトリの実装クラスを記述
- Roomリポジトリの実装クラスもテストケース追加したり並列化したりした。

## Preview
<img width="254" alt="スクリーンショット 2021-04-08 1 47 42" src="https://user-images.githubusercontent.com/38310693/113903882-69fab680-980c-11eb-8a31-b1483ce7e5bb.png">

