### PR TITLE
refactor: DBからエンティティに変換する際のファクトリを作成

### DIFF
--- a/infrastructure/mysql/message/dto.go
+++ b/infrastructure/mysql/message/dto.go
@@ -3,7 +3,7 @@ package message
 import (
 	"github.com/oklog/ulid"
 
-	domain "github.com/karamaru-alpha/chat-go-server/domain/model/message"
+	messageDomain "github.com/karamaru-alpha/chat-go-server/domain/model/message"
 	roomDomain "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 )
 
@@ -15,7 +15,7 @@ type Message struct {
 }
 
 // ToDTO メッセージエンティティをDB情報を持った構造体に変換する
-func ToDTO(entity *domain.Message) *Message {
+func ToDTO(entity *messageDomain.Message) *Message {
 	if entity == nil {
 		return nil
 	}
@@ -28,17 +28,12 @@ func ToDTO(entity *domain.Message) *Message {
 }
 
 // ToEntity DB情報を持った構造体からメッセージエンティティに変換する
-func ToEntity(dto *Message) (*domain.Message, error) {
+func ToEntity(dto *Message) (*messageDomain.Message, error) {
 	if dto == nil {
 		return nil, nil
 	}
 
-	parsedULID, err := ulid.Parse(dto.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	entityID, err := domain.NewID(&parsedULID)
+	parsedMessageULID, err := ulid.Parse(dto.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -48,30 +43,20 @@ func ToEntity(dto *Message) (*domain.Message, error) {
 		return nil, err
 	}
 
-	entityRoomID, err := roomDomain.NewID(&parsedRoomULID)
-	if err != nil {
-		return nil, err
-	}
-
-	entityBody, err := domain.NewBody(dto.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return domain.NewMessage(
-		entityID,
-		entityRoomID,
-		entityBody,
-	)
+	return &messageDomain.Message{
+		ID:     messageDomain.ID(parsedMessageULID),
+		RoomID: roomDomain.ID(parsedRoomULID),
+		Body:   messageDomain.Body(dto.Body),
+	}, nil
 }
 
 // ToEntity DB情報を持った構造体のスライスをエンティティに変換する
-func ToEntities(dtos *[]Message) (*[]domain.Message, error) {
+func ToEntities(dtos *[]Message) (*[]messageDomain.Message, error) {
 	if dtos == nil {
 		return nil, nil
 	}
 
-	entities := make([]domain.Message, 0, len(*dtos))
+	entities := make([]messageDomain.Message, 0, len(*dtos))
 	for _, v := range *dtos {
 		entity, err := ToEntity(&v)
 		if err != nil {

--- a/infrastructure/mysql/room/dto.go
+++ b/infrastructure/mysql/room/dto.go
@@ -35,20 +35,10 @@ func ToEntity(dto *Room) (*domain.Room, error) {
 		return nil, err
 	}
 
-	entityID, err := domain.NewID(&parsedULID)
-	if err != nil {
-		return nil, err
-	}
-
-	entityTitle, err := domain.NewTitle(dto.Title)
-	if err != nil {
-		return nil, err
-	}
-
-	return domain.NewRoom(
-		entityID,
-		entityTitle,
-	)
+	return &domain.Room{
+		ID:    domain.ID(parsedULID),
+		Title: domain.Title(dto.Title),
+	}, nil
 }
 
 // ToEntities DB情報を持った複数の構造体をトークルームエンティティに変換する

--- a/test/infrastructure/mysql/message/dto_test.go
+++ b/test/infrastructure/mysql/message/dto_test.go
@@ -94,26 +94,6 @@ func TestToEntity(t *testing.T) {
 			expected1: nil,
 			expected2: errors.New("ulid: bad data size when unmarshaling"),
 		},
-		{
-			title: "【異常系】Bodyが不正値(empty)",
-			input: &infra.Message{
-				ID:     tdString.Message.ID.Valid,
-				RoomID: tdString.Room.ID.Valid,
-				Body:   tdString.Message.Body.Empty,
-			},
-			expected1: nil,
-			expected2: errors.New("MessageBody is empty"),
-		},
-		{
-			title: "【異常系】Bodyが不正値(long)",
-			input: &infra.Message{
-				ID:     tdString.Message.ID.Valid,
-				RoomID: tdString.Room.ID.Valid,
-				Body:   tdString.Message.Body.TooLong,
-			},
-			expected1: nil,
-			expected2: errors.New("MessageBody should be 1 to 255 characters"),
-		},
 	}
 
 	for _, td := range tests {

--- a/test/infrastructure/mysql/room/dto_test.go
+++ b/test/infrastructure/mysql/room/dto_test.go
@@ -72,24 +72,6 @@ func TestToEntity(t *testing.T) {
 			expected1: nil,
 			expected2: errors.New("ulid: bad data size when unmarshaling"),
 		},
-		{
-			title:     "【異常系】タイトルが空文字列",
-			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: ""},
-			expected1: nil,
-			expected2: errors.New("RoomTitle is null"),
-		},
-		{
-			title:     "【異常系】タイトルが不正値(short)",
-			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooShort},
-			expected1: nil,
-			expected2: errors.New("RoomTitle should be Three to twenty characters"),
-		},
-		{
-			title:     "【異常系】タイトルが不正値(long)",
-			input:     &infra.Room{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooLong},
-			expected1: nil,
-			expected2: errors.New("RoomTitle should be Three to twenty characters"),
-		},
 	}
 
 	for _, td := range tests {
@@ -136,16 +118,10 @@ func TestToEntities(t *testing.T) {
 			expected2: nil,
 		},
 		{
-			title:     "【異常系】タイトルが不正値(short)",
-			input:     &[]infra.Room{{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooShort}},
+			title:     "【異常系】IDが不正値",
+			input:     &[]infra.Room{{ID: tdString.Room.ID.Invalid, Title: tdString.Room.Title.Valid}},
 			expected1: nil,
-			expected2: errors.New("RoomTitle should be Three to twenty characters"),
-		},
-		{
-			title:     "【異常系】タイトルが不正値(long)",
-			input:     &[]infra.Room{{ID: tdString.Room.ID.Valid, Title: tdString.Room.Title.TooLong}},
-			expected1: nil,
-			expected2: errors.New("RoomTitle should be Three to twenty characters"),
+			expected2: errors.New("ulid: bad data size when unmarshaling"),
 		},
 	}
 


### PR DESCRIPTION
## About
DBからエンティティに変換する際のファクトリを作成
## Background
ドメインロジックを変更した時、値オブジェクトを経由してDBからエンティティを作成するとエラーで取り出せなくなるため。独自の生成処理が必要
## Details
dtoで値オブジェクトにそのままcastする
