### PR TITLE
refactor: メッセージリポジトリの永続化処理をSaveに改名

### DIFF
--- a/application/message/create/interactor.go
+++ b/application/message/create/interactor.go
@@ -53,7 +53,7 @@ func (i interactor) Handle(input InputData) OutputData {
 		return OutputData{Err: err}
 	}
 
-	if err = i.messageRepository.Create(message); err != nil {
+	if err = i.messageRepository.Save(message); err != nil {
 		return OutputData{Err: err}
 	}
 

--- a/domain/model/message/repository.go
+++ b/domain/model/message/repository.go
@@ -4,6 +4,6 @@ import "github.com/karamaru-alpha/chat-go-server/domain/model/room"
 
 // IRepository メッセージエンティティの永続化・再構築を実現するリポジトリ
 type IRepository interface {
-	Create(*Message) error
+	Save(*Message) error
 	FindAll(*room.ID) (*[]Message, error)
 }

--- a/infrastructure/mysql/message/repository_impl.go
+++ b/infrastructure/mysql/message/repository_impl.go
@@ -21,8 +21,8 @@ func NewRepositoryImpl(db *gorm.DB) messageDomain.IRepository {
 	}
 }
 
-// Create メッセージの永続化を行う
-func (r repositoryImpl) Create(entity *messageDomain.Message) error {
+// Save メッセージの永続化を行う
+func (r repositoryImpl) Save(entity *messageDomain.Message) error {
 	dto := ToDTO(entity)
 	return r.db.Create(dto).Error
 }

--- a/mock/domain/model/message/repository_mock.go
+++ b/mock/domain/model/message/repository_mock.go
@@ -35,20 +35,6 @@ func (m *MockIRepository) EXPECT() *MockIRepositoryMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
-func (m *MockIRepository) Create(arg0 *message.Message) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Create indicates an expected call of Create.
-func (mr *MockIRepositoryMockRecorder) Create(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockIRepository)(nil).Create), arg0)
-}
-
 // FindAll mocks base method.
 func (m *MockIRepository) FindAll(arg0 *room.ID) (*[]message.Message, error) {
 	m.ctrl.T.Helper()
@@ -62,4 +48,18 @@ func (m *MockIRepository) FindAll(arg0 *room.ID) (*[]message.Message, error) {
 func (mr *MockIRepositoryMockRecorder) FindAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockIRepository)(nil).FindAll), arg0)
+}
+
+// Save mocks base method.
+func (m *MockIRepository) Save(arg0 *message.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Save", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Save indicates an expected call of Save.
+func (mr *MockIRepositoryMockRecorder) Save(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockIRepository)(nil).Save), arg0)
 }

--- a/test/application/message/create/interactor_test.go
+++ b/test/application/message/create/interactor_test.go
@@ -42,7 +42,7 @@ func TestHandle(t *testing.T) {
 			title: "【正常系】",
 			before: func() {
 				roomRepository.EXPECT().Find(&tdRoomDomain.Room.ID).Return(&tdRoomDomain.Room.Entity, nil)
-				messageRepository.EXPECT().Create(&tdMessageDomain.Message.Entity).Return(nil)
+				messageRepository.EXPECT().Save(&tdMessageDomain.Message.Entity).Return(nil)
 			},
 			input: application.InputData{
 				RoomID: tdString.Room.ID.Valid,

--- a/test/infrastructure/mysql/message/repository_impl_test.go
+++ b/test/infrastructure/mysql/message/repository_impl_test.go
@@ -21,7 +21,7 @@ type repositoryImplTester struct {
 	mock           sqlmock.Sqlmock
 }
 
-// TestCreate メッセージを永続化させる処理のテスト
+// TestSave メッセージを永続化させる処理のテスト
 func TestSave(t *testing.T) {
 	t.Parallel()
 
@@ -36,7 +36,7 @@ func TestSave(t *testing.T) {
 	tester.mock.ExpectCommit()
 
 	// 実行
-	err := tester.repositoryImpl.Create(&tdMessageDomain.Message.Entity)
+	err := tester.repositoryImpl.Save(&tdMessageDomain.Message.Entity)
 	assert.NoError(t, err)
 
 	err = tester.mock.ExpectationsWereMet()


### PR DESCRIPTION
## About
メッセージリポジトリの永続化処理をSaveに改名
## Background
`Create`はエンティティのコンストラクタが行う。
永続化には`Save`など、すでに作成された物を永続化する名前が好ましい。
## Details
`MessageRepository#Create` -> `MessageRepository#Save`
