### PR TITLE
refactor: トークルーム入室アプリケーションサービスの改名

### DIFF
--- a/application/message/find_all/input_data.go
+++ b/application/message/find_all/input_data.go
@@ -1,6 +1,0 @@
-package message
-
-// InputData メッセージ一覧取得の入力データ
-type InputData struct {
-	RoomID string
-}

--- a/application/message/find_all/input_port.go
+++ b/application/message/find_all/input_port.go
@@ -1,6 +1,0 @@
-package message
-
-// IInputPort メッセージ一覧取得アプリケーションサービスのインターフェース
-type IInputPort interface {
-	Handle(InputData) OutputData
-}

--- a/application/room/join/input_data.go
+++ b/application/room/join/input_data.go
@@ -1,0 +1,6 @@
+package message
+
+// InputData トークルーム入室の入力データ
+type InputData struct {
+	RoomID string
+}

--- a/application/room/join/input_port.go
+++ b/application/room/join/input_port.go
@@ -1,0 +1,6 @@
+package message
+
+// IInputPort トークルーム入室アプリケーションサービスのインターフェース
+type IInputPort interface {
+	Handle(InputData) OutputData
+}

--- a/application/room/join/interactor.go
+++ b/application/room/join/interactor.go
@@ -11,14 +11,14 @@ type interactor struct {
 	repository messageDomain.IRepository
 }
 
-// NewInteractor メッセージ一覧取得アプリケーションサービスのコンストラクタ
+// NewInteractor トークルーム入室アプリケーションサービスのコンストラクタ
 func NewInteractor(r messageDomain.IRepository) IInputPort {
 	return &interactor{
 		repository: r,
 	}
 }
 
-// Handle メッセージ一覧取得アプリケーションサービス
+// Handle トークルーム入室アプリケーションサービス
 func (i interactor) Handle(input InputData) OutputData {
 
 	parsedULID, err := ulid.Parse(input.RoomID)

--- a/application/room/join/output_data.go
+++ b/application/room/join/output_data.go
@@ -4,7 +4,7 @@ import (
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
 )
 
-// OutputData メッセージ一覧取得のアプリケーションサービスの出力
+// OutputData トークルーム入室アプリケーションサービスの出力
 type OutputData struct {
 	Messages *[]domainModel.Message
 	Err      error

--- a/test/application/room/join/interactor_test.go
+++ b/test/application/room/join/interactor_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	application "github.com/karamaru-alpha/chat-go-server/application/message/find_all"
+	application "github.com/karamaru-alpha/chat-go-server/application/room/join"
 	domainModel "github.com/karamaru-alpha/chat-go-server/domain/model/message"
 	mockDomainModel "github.com/karamaru-alpha/chat-go-server/mock/domain/model/message"
 	tdDomain "github.com/karamaru-alpha/chat-go-server/test/testdata/domain/message"
@@ -15,7 +15,7 @@ import (
 	tdString "github.com/karamaru-alpha/chat-go-server/test/testdata/string"
 )
 
-// TestHandle トークルームを全件取得するアプリケーションサービスのテスト
+// TestHandle トークルーム入室アプリケーションサービスのテスト
 func TestHandle(t *testing.T) {
 	t.Parallel()
 
@@ -34,7 +34,7 @@ func TestHandle(t *testing.T) {
 		expected application.OutputData
 	}{
 		{
-			title: "【正常系】メッセージが1件",
+			title: "【正常系】トークルームのメッセージが1件",
 			before: func() {
 				repository.EXPECT().FindAll(&tdRoomDomain.Room.ID).Return(
 					&[]domainModel.Message{tdDomain.Message.Entity}, nil,


### PR DESCRIPTION
## About
トークルーム入室アプリケーションサービスの改名
## Background
従来は`message/find_all`であるが、それは技術用件であって、ユースケース的には`room/join`が正しい。
