### PR TITLE
refactor: マジックナンバーをなくす

### DIFF
--- a/domain/model/message/body.go
+++ b/domain/model/message/body.go
@@ -2,8 +2,12 @@ package message
 
 import (
 	"errors"
+	"fmt"
 	"unicode/utf8"
 )
+
+const BODY_MIN_LEN = 1
+const BODY_MAX_LEN = 255
 
 // Body メッセージ本文を表す値オブジェクト
 type Body string
@@ -13,8 +17,8 @@ func NewBody(v string) (Body, error) {
 	if v == "" {
 		return "", errors.New("MessageBody is empty")
 	}
-	if utf8.RuneCountInString(v) == 0 || utf8.RuneCountInString(v) > 255 {
-		return "", errors.New("MessageBody should be 1 to 255 characters")
+	if utf8.RuneCountInString(v) < BODY_MIN_LEN || utf8.RuneCountInString(v) > BODY_MAX_LEN {
+		return "", fmt.Errorf("MessageBody should be %d to %d characters", BODY_MIN_LEN, BODY_MAX_LEN)
 	}
 
 	return Body(v), nil

--- a/domain/model/room/title.go
+++ b/domain/model/room/title.go
@@ -2,8 +2,12 @@ package room
 
 import (
 	"errors"
+	"fmt"
 	"unicode/utf8"
 )
+
+const TITLE_MIN_LEN = 3
+const TITLE_MAX_LEN = 50
 
 // Title トークルーム名を表現する値オブジェクト
 type Title string
@@ -13,8 +17,8 @@ func NewTitle(v string) (Title, error) {
 	if v == "" {
 		return "", errors.New("RoomTitle is null")
 	}
-	if utf8.RuneCountInString(v) < 3 || utf8.RuneCountInString(v) > 50 {
-		return "", errors.New("RoomTitle should be Three to twenty characters")
+	if utf8.RuneCountInString(v) < TITLE_MIN_LEN || utf8.RuneCountInString(v) > TITLE_MAX_LEN {
+		return "", fmt.Errorf("RoomTitle should be %d to %d characters", TITLE_MIN_LEN, TITLE_MAX_LEN)
 	}
 
 	return Title(v), nil

--- a/test/application/room/create/interactor_test.go
+++ b/test/application/room/create/interactor_test.go
@@ -66,7 +66,7 @@ func TestHandle(t *testing.T) {
 			},
 			expected: application.OutputData{
 				Room: domain.Room{},
-				Err:  errors.New("RoomTitle should be Three to twenty characters"),
+				Err:  errors.New("RoomTitle should be 3 to 50 characters"),
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestHandle(t *testing.T) {
 			},
 			expected: application.OutputData{
 				Room: domain.Room{},
-				Err:  errors.New("RoomTitle should be Three to twenty characters"),
+				Err:  errors.New("RoomTitle should be 3 to 50 characters"),
 			},
 		},
 		{

--- a/test/domain/model/room/title_test.go
+++ b/test/domain/model/room/title_test.go
@@ -38,13 +38,13 @@ func TestNewTitle(t *testing.T) {
 			title:     "【異常系】タイトルが短い",
 			input:     tdString.Title.TooShort,
 			expected1: "",
-			expected2: errors.New("RoomTitle should be Three to twenty characters"),
+			expected2: errors.New("RoomTitle should be 3 to 50 characters"),
 		},
 		{
 			title:     "【異常系】タイトルが長い",
 			input:     tdString.Title.TooLong,
 			expected1: "",
-			expected2: errors.New("RoomTitle should be Three to twenty characters"),
+			expected2: errors.New("RoomTitle should be 3 to 50 characters"),
 		},
 	}
 

--- a/test/testdata/string/message/td.go
+++ b/test/testdata/string/message/td.go
@@ -1,6 +1,10 @@
 package testdata
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/karamaru-alpha/chat-go-server/domain/model/message"
+)
 
 // Body メッセージ本文に関連する文字列テストデータ
 var Body = struct {
@@ -8,5 +12,5 @@ var Body = struct {
 }{
 	Valid:   "valid_message_body",
 	Empty:   "",
-	TooLong: strings.Repeat("a", 256),
+	TooLong: strings.Repeat("a", message.BODY_MAX_LEN+1),
 }

--- a/test/testdata/string/room/td.go
+++ b/test/testdata/string/room/td.go
@@ -1,12 +1,16 @@
 package testdata
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/karamaru-alpha/chat-go-server/domain/model/room"
+)
 
 // Title トークルームタイトルに関連する文字列のテストデータ
 var Title = struct {
 	Valid, TooShort, TooLong string
 }{
 	Valid:    "valid_title",
-	TooShort: ".",
-	TooLong:  strings.Repeat("a", 100),
+	TooShort: strings.Repeat("a", room.TITLE_MIN_LEN-1),
+	TooLong:  strings.Repeat("a", room.TITLE_MAX_LEN+1),
 }


### PR DESCRIPTION
## About
refactor: マジックナンバーをなくす
## Background
ドメイン知識のバリデーションにまつわる数字のマジックナンバーを表現し直す
